### PR TITLE
v0.3.9 camera zoom

### DIFF
--- a/core/src/contrib/systems/ui/InputSystem.ts
+++ b/core/src/contrib/systems/ui/InputSystem.ts
@@ -9,10 +9,14 @@ export const charactersPreventDefault = new Set(["'", "/", " "]);
 // InputSystem handles all keyboard/joystick inputs
 export const InputSystem = ClientSystemBuilder({
   id: "InputSystem",
-  init: ({ clientPlayerId, world }) => {
+  init: ({ clientPlayerId, world, renderer }) => {
     let bufferedDown: Set<string> = new Set([]);
     let bufferedUp: Set<string> = new Set([]);
     let backspaceOn = false;
+
+    renderer?.props.canvas.addEventListener("wheel", (event) => {
+      renderer.camera.rescaleDelta(-event.deltaY / 1000);
+    });
 
     document.addEventListener("keyup", (event: KeyboardEvent) => {
       if (document.hasFocus()) {

--- a/core/src/contrib/systems/ui/RenderSystem.ts
+++ b/core/src/contrib/systems/ui/RenderSystem.ts
@@ -122,7 +122,11 @@ export const RenderSystem = ClientSystemBuilder({
 
       await renderable._init(renderer);
 
-      renderer.addWorld(renderable);
+      if (position.screenFixed) {
+        renderer.addGui(renderable);
+      } else {
+        renderer.addWorld(renderable);
+      }
     }
 
     // updates the position of screenFixed entities
@@ -131,15 +135,15 @@ export const RenderSystem = ClientSystemBuilder({
       if (position.screenFixed) {
 
         if (position.data.x < 0) {
-          renderable.c.x = renderer.app.screen.width + position.data.x - renderer.camera.c.x;
+          renderable.c.x = renderer.app.screen.width + position.data.x;
         } else {
-          renderable.c.x = position.data.x - renderer.camera.c.x;
+          renderable.c.x = position.data.x;
         }
 
         if (position.data.y < 0) {
-          renderable.c.y = renderer.app.screen.height + position.data.y - renderer.camera.c.y;
+          renderable.c.y = renderer.app.screen.height + position.data.y;
         } else {
-          renderable.c.y = position.data.y - renderer.camera.c.y;
+          renderable.c.y = position.data.y;
         }
       }
     }

--- a/core/src/graphics/Camera.ts
+++ b/core/src/graphics/Camera.ts
@@ -1,11 +1,16 @@
 import { Renderer, Renderable } from "@piggo-gg/core";
 import { Container } from "pixi.js";
 
+const scaleMin = 1;
+const scaleMax = 2;
+
 // Camera handles the viewport of the game
 export class Camera {
   renderables: Set<Renderable> = new Set();
   renderer: Renderer;
   c: Container = new Container();
+
+  scale = 1;
 
   constructor(renderer: Renderer) {
     this.renderer = renderer;
@@ -13,6 +18,23 @@ export class Camera {
     this.c.sortableChildren = true;
     this.c.zIndex = 0;
     this.c.alpha = 1;
+
+    this.rescale();
+  }
+
+  rescale = () => {
+    if (this.scale < scaleMin) {
+      this.scale = scaleMin;
+    } else if (this.scale > scaleMax) {
+      this.scale = scaleMax;
+    }
+
+    this.c.scale.set(this.scale, this.scale);
+  }
+
+  rescaleDelta = (delta: number) => {
+    this.scale += delta;
+    this.rescale();
   }
 
   add = (r: Renderable) => {
@@ -21,8 +43,8 @@ export class Camera {
   }
 
   moveTo = ({ x, y }: { x: number, y: number }) => {
-    this.c.x = this.renderer.app.screen.width / 2 - x;
-    this.c.y = this.renderer.app.screen.height / 2 - y;
+    this.c.x = this.renderer.app.screen.width / 2 - x * this.scale;
+    this.c.y = this.renderer.app.screen.height / 2 - y * this.scale;
   }
 
   toWorldCoords = ({ x, y }: { x: number, y: number }) => ({

--- a/core/src/graphics/Camera.ts
+++ b/core/src/graphics/Camera.ts
@@ -1,9 +1,6 @@
 import { Renderer, Renderable } from "@piggo-gg/core";
 import { Container } from "pixi.js";
 
-const scaleMin = 1;
-const scaleMax = 2;
-
 // Camera handles the viewport of the game
 export class Camera {
   renderables: Set<Renderable> = new Set();
@@ -23,10 +20,13 @@ export class Camera {
   }
 
   rescale = () => {
-    if (this.scale < scaleMin) {
-      this.scale = scaleMin;
-    } else if (this.scale > scaleMax) {
-      this.scale = scaleMax;
+    const min = 1;
+    const max = 2;
+
+    if (this.scale < min) {
+      this.scale = min;
+    } else if (this.scale > max) {
+      this.scale = max;
     }
 
     this.c.scale.set(this.scale, this.scale);

--- a/core/src/graphics/Renderer.ts
+++ b/core/src/graphics/Renderer.ts
@@ -25,7 +25,7 @@ export class Renderer {
     // create the pixi.js application
     await this.app.init({
       view: this.props.canvas,
-      resolution: 2, // TODO configurable
+      resolution: 1, // TODO configurable
       autoDensity: true,
       backgroundColor: 0x6495ed,
       width: this.props.width ?? 800,
@@ -37,9 +37,6 @@ export class Renderer {
 
     // set up the camera
     this.camera = new Camera(this);
-    // this.camera.c.addChild(this.app.stage);
-    // this.app.stage = this.camera.c;
-
     this.app.stage.addChild(this.camera.c);
 
     // hide the cursor

--- a/core/src/graphics/Renderer.ts
+++ b/core/src/graphics/Renderer.ts
@@ -25,7 +25,7 @@ export class Renderer {
     // create the pixi.js application
     await this.app.init({
       view: this.props.canvas,
-      resolution: 1, // TODO configurable
+      resolution: 2, // TODO configurable
       autoDensity: true,
       backgroundColor: 0x6495ed,
       width: this.props.width ?? 800,
@@ -37,8 +37,10 @@ export class Renderer {
 
     // set up the camera
     this.camera = new Camera(this);
-    this.camera.c.addChild(this.app.stage);
-    this.app.stage = this.camera.c;
+    // this.camera.c.addChild(this.app.stage);
+    // this.app.stage = this.camera.c;
+
+    this.app.stage.addChild(this.camera.c);
 
     // hide the cursor
     this.app.renderer.events.cursorStyles.default = "none";
@@ -64,7 +66,11 @@ export class Renderer {
     }
   }
 
+  addGui = (renderable: Renderable) => {
+    if (renderable) this.app.stage.addChild(renderable.c);
+  }
+
   addWorld = (renderable: Renderable) => {
-    this.camera.add(renderable);
+    if (renderable) this.camera.add(renderable);
   }
 }

--- a/core/src/runtime/World.ts
+++ b/core/src/runtime/World.ts
@@ -181,9 +181,9 @@ export const World = ({ clientPlayerId, commands, games, renderer, renderMode, r
       if (!isRollback) scheduleOnTick();
 
       // clear old buffered data
-      world.actionBuffer.clearBeforeTick(world.tick - 100);
+      world.actionBuffer.clearBeforeTick(world.tick - 5);
       Object.keys(world.entitiesAtTick).map(Number).forEach((tick) => {
-        if ((world.tick - tick) > 100) {
+        if ((world.tick - tick) > 5) {
           delete world.entitiesAtTick[tick];
         }
       });

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -23,7 +23,7 @@ export const Header = ({ world, netState, setNetState }: HeaderProps) => {
       </h1>
       <div style={{ position: 'absolute', right: 0, bottom: 0 }}>
         <span style={{ fontFamily: "sans-serif", fontSize: 14, marginRight: 5, verticalAlign: "-70%" }}>
-          v<b>0.3.8</b>
+          v<b>0.3.9</b>
         </span>
         <a style={{ margin: 0, color: "inherit", textDecoration: "none" }} target="_blank" href="https://discord.gg/VfFG9XqDpJ">
           <FaDiscord size={20} style={{ color: "white", verticalAlign: "-80%" }}></FaDiscord>


### PR DESCRIPTION
- on scrolling in or out, `renderer.camera.scale` changes
- entities with `position.screenFixed` are now children of `renderer.app.stage` instead of `renderer.camera` (so GUI elements don't scale with zoom)

|zoom out| zoom in|
|--|--|
|<img width="745" alt="Screenshot 2024-04-06 at 4 22 39 PM" src="https://github.com/alexanderclarktx/piggo-gg/assets/9264428/8bf67034-7cfe-4e04-89ab-fd24af567285">|<img width="750" alt="Screenshot 2024-04-06 at 4 22 49 PM" src="https://github.com/alexanderclarktx/piggo-gg/assets/9264428/a1dbed9e-8089-465a-96b2-6c0ef5060c23">|