### PR TITLE
v0.5.4 piggo strike map update

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "./main.ts",
   "dependencies": {
-    "@dimforge/rapier2d-compat": "0.12.0",
+    "@dimforge/rapier2d-compat": "0.13.1",
     "@pixi/ui": "2.0.1",
     "pixi-filters": "6.0.3",
     "pixi.js": "8.1.1",

--- a/core/src/contrib/components/Collider.ts
+++ b/core/src/contrib/components/Collider.ts
@@ -5,13 +5,14 @@ export type ColliderShapes = "ball" | "cuboid" | "line";
 
 export type ColliderProps = {
   shape: ColliderShapes
+  shootable?: boolean
   points?: number[]
   radius?: number
   length?: number
   width?: number
   isStatic?: boolean
   frictionAir?: number
-  mass?: number // default mass seems to be 100
+  mass?: number // default 100
   restitution?: number
   rotation?: number
   priority?: number
@@ -24,11 +25,12 @@ export class Collider extends Component<"collider"> {
   colliderDesc: ColliderDesc;
   rapierCollider: RapierCollider;
   body: RigidBody;
-  priority: number = 0;
+  priority: number;
+  shootable: boolean;
 
   sensor: (e2: Entity<Position>, world: World) => void;
 
-  constructor({ shape, points, radius, length, width, isStatic, frictionAir, mass, restitution, sensor, rotation, priority }: ColliderProps) {
+  constructor({ shape, shootable, points, radius, length, width, isStatic, frictionAir, mass, restitution, sensor, rotation, priority }: ColliderProps) {
     super();
 
     if (isStatic) {
@@ -38,11 +40,11 @@ export class Collider extends Component<"collider"> {
     }
 
     if (shape === "ball" && radius) {
-      this.colliderDesc = ColliderDesc.ball(radius)
+      this.colliderDesc = ColliderDesc.ball(radius);
     } else if (shape === "cuboid") {
       this.colliderDesc = ColliderDesc.cuboid(length ?? 1, width ?? 1);
     } else if (shape === "line" && points) {
-      const s = ColliderDesc.polyline(Float32Array.from(points))
+      const s = ColliderDesc.polyline(Float32Array.from(points));
       this.colliderDesc = s;
     }
 
@@ -51,7 +53,9 @@ export class Collider extends Component<"collider"> {
       this.sensor = sensor;
     }
 
-    if (priority) this.priority = priority;
+    this.shootable = shootable ?? true;
+
+    this.priority = priority ?? 0;
 
     if (mass) this.colliderDesc.setMass(mass);
     if (restitution) this.colliderDesc.setRestitution(restitution);

--- a/core/src/contrib/components/Controller.ts
+++ b/core/src/contrib/components/Controller.ts
@@ -1,14 +1,14 @@
-import { InvokedAction, Component, Entity } from "@piggo-gg/core";
+import { InvokedAction, Component, Entity, Position } from "@piggo-gg/core";
 
 export type ControllerInput = {
   mouse: { x: number, y: number }
-  entity: Entity
+  entity: Entity<Position>
 }
 
 // "" is always allowed to clear the input buffer
 export type ControllerMap<P extends {}> = {
   keyboard: Record<string, (_: ControllerInput) => null | InvokedAction<string, P>>
-  joystick: () => null | InvokedAction<string, P>
+  joystick: (_: { entity: Entity<Position> }) => null | InvokedAction<string, P>
 }
 
 // the Controller component maps inputs to Actions

--- a/core/src/contrib/components/Gun.ts
+++ b/core/src/contrib/components/Gun.ts
@@ -43,7 +43,7 @@ export class Gun extends Component<"gun"> {
   }
 }
 
-export const Pistol = new Gun({ name: "pistol", damage: 10, speed: 300, clipSize: 7, reloadTime: 1, fireRate: 30 });
+export const Pistol = new Gun({ name: "pistol", damage: 10, speed: 400, clipSize: 7, reloadTime: 1, fireRate: 30 });
 export const Shotgun = new Gun({ name: "shotgun", damage: 20, speed: 150, clipSize: 2, reloadTime: 2, fireRate: 2 });
 export const MachineGun = new Gun({ name: "machinegun", damage: 5, speed: 300, clipSize: 30, reloadTime: 3, fireRate: 10 });
 export const Sniper = new Gun({ name: "sniper", damage: 50, speed: 400, clipSize: 1, reloadTime: 2, fireRate: 2 });

--- a/core/src/contrib/components/Health.ts
+++ b/core/src/contrib/components/Health.ts
@@ -4,7 +4,6 @@ export type HealthProps = {
   health: number,
   maxHealth: number,
   showHealthBar?: boolean
-  shootable?: boolean
 }
 
 // the health component includes health, maxHealth, and damage
@@ -15,14 +14,12 @@ export class Health extends Component<"health"> {
     health: 0,
     maxHealth: 0,
     showHealthBar: true,
-    shootable: false
   }
 
-  constructor({health, maxHealth, showHealthBar, shootable}: HealthProps) {
+  constructor({health, maxHealth, showHealthBar}: HealthProps) {
     super();
     this.data.health = health;
     this.data.maxHealth = maxHealth;
     this.data.showHealthBar = showHealthBar ?? true;
-    this.data.shootable = shootable ?? false;
   }
 }

--- a/core/src/contrib/components/Renderable.ts
+++ b/core/src/contrib/components/Renderable.ts
@@ -141,7 +141,9 @@ export class Renderable extends Component<"renderable"> {
     // remove all event listeners
     this.c.removeAllListeners();
 
-    this.c.visible = false;
+    // this.c.visible = false;
+
+    this.c.renderable = false;
 
     // remove from the world
     // this.c.destroy(); // TODO disabled because it breaks from collider debug

--- a/core/src/contrib/components/Renderable.ts
+++ b/core/src/contrib/components/Renderable.ts
@@ -72,7 +72,7 @@ export class Renderable extends Component<"renderable"> {
   overrideDynamic = (dynamic: undefined | ((c: Container, r: Renderable, e: Entity, w: World) => void)) => {
     return (c: Container, r: Renderable, e: Entity, w: World) => {
       if (dynamic) dynamic(c, r, e, w);
-      if (this.c.visible !== this.visible) this.c.visible = this.visible;
+      if (this.c.renderable !== this.visible) this.c.renderable = this.visible;
     }
   }
 
@@ -120,7 +120,7 @@ export class Renderable extends Component<"renderable"> {
     this.interactiveChildren ? this.c.interactiveChildren = true : this.c.interactiveChildren = false;
 
     // set visible
-    this.c.visible = this.visible ?? true;
+    this.c.renderable = this.visible ?? true;
 
     // set container properties
     this.c.zIndex = this.zIndex || 0;
@@ -141,11 +141,9 @@ export class Renderable extends Component<"renderable"> {
     // remove all event listeners
     this.c.removeAllListeners();
 
-    // this.c.visible = false;
-
     this.c.renderable = false;
 
     // remove from the world
-    // this.c.destroy(); // TODO disabled because it breaks from collider debug
+    // this.c.destroy(); // TODO disabled because it breaks debug mode
   }
 }

--- a/core/src/contrib/entities/characters/Skelly.ts
+++ b/core/src/contrib/entities/characters/Skelly.ts
@@ -6,7 +6,7 @@ export const Skelly = (id: string, color?: number) => {
     id: id,
     components: {
       debug: new Debug(),
-      position: new Position({ x: 151, y: 300, velocityResets: 1, speed: 120 }),
+      position: new Position({ x: 151, y: 300, velocityResets: 1, speed: 160 }),
       networked: new Networked({ isNetworked: true }),
       controlled: new Controlled({ entityId: "" }),
       collider: new Collider({ shape: "ball", radius: 8, mass: 600 }),

--- a/core/src/contrib/entities/characters/Zombie.ts
+++ b/core/src/contrib/entities/characters/Zombie.ts
@@ -12,7 +12,7 @@ export const Zombie = ({ id, color, positionProps = { x: 100, y: 100 } }: Zombie
   components: {
     position: new Position({ ...positionProps, velocityResets: 1, speed: positionProps.speed ?? 30 }),
     networked: new Networked({ isNetworked: true }),
-    health: new Health({ health: 100, maxHealth: 100, shootable: true }),
+    health: new Health({ health: 100, maxHealth: 100 }),
     npc: new NPC<ZombieMovementActions>({
       onTick: (_) => ({ action: "chase" })
     }),

--- a/core/src/contrib/entities/objects/Projectile.ts
+++ b/core/src/contrib/entities/objects/Projectile.ts
@@ -19,9 +19,11 @@ export const Projectile = ({ radius, pos, id }: ProjectileProps) => {
       collider: new Collider({
         shape: "ball",
         radius: radius ?? 10,
-        sensor: (e2: Entity<Position>, world: World) => {
-          if (e2.components.health && e2.components.health.data.shootable) {
-            e2.components.health.data.health -= 25;
+        sensor: (e2: Entity<Position | Collider>, world: World) => {
+          if (e2.components.collider.shootable) {
+            if (e2.components.health) {
+              e2.components.health.data.health -= 25;
+            }
             world.removeEntity(projectile.id);
           }
         }

--- a/core/src/contrib/entities/terrain/FloorTiles.ts
+++ b/core/src/contrib/entities/terrain/FloorTiles.ts
@@ -8,9 +8,10 @@ export type FloorTilesProps = {
   cols: number
   position?: { x: number, y: number }
   id?: string
+  tint?: number
 }
 
-export const FloorTiles = ({ rows, cols, position = { x: 0, y: 0 }, id = `floor${index++}` }: FloorTilesProps): Entity => {
+export const FloorTiles = ({ tint, rows, cols, position = { x: 0, y: 0 }, id = `floor${index++}` }: FloorTilesProps): Entity => {
 
   const makeTiles = async (r: Renderer) => {
     const sandbox = await Assets.load("sandbox.json");
@@ -22,7 +23,7 @@ export const FloorTiles = ({ rows, cols, position = { x: 0, y: 0 }, id = `floor$
     tile.anchor.set(0.5, 0.5);
     tile.scale.set(2);
     tile.eventMode = "static";
-    tile.tint = 0x7777aa;
+    tile.tint = tint ?? 0x7777aa;
 
     // create a render texture
     const renderTexture = RenderTexture.create({

--- a/core/src/contrib/entities/terrain/FloorTiles.ts
+++ b/core/src/contrib/entities/terrain/FloorTiles.ts
@@ -1,5 +1,5 @@
-import { Entity, Renderer, Position, Renderable, Debug } from "@piggo-gg/core";
-import { Assets, Texture, Sprite, RenderTexture, Matrix, Graphics } from "pixi.js";
+import { Entity, Position, Renderable, Renderer } from "@piggo-gg/core";
+import { Assets, Matrix, RenderTexture, Sprite, Texture } from "pixi.js";
 
 let index = 0;
 
@@ -10,6 +10,14 @@ export type FloorTilesProps = {
   id?: string
   tint?: number
 }
+
+export const FloorTilesPoints = (rows: number, cols: number, x: number, y: number) => [
+  32 + x, 0 + y,
+  (cols * 32 + 32) + x, (cols * 16) + y,
+  ((cols - rows) * 32 + 32) + x, ((cols + rows) * 16) + y,
+  (-rows * 32 + 32) + x, (rows * 16) + y,
+  32 + x, 0 + y
+]
 
 export const FloorTiles = ({ tint, rows, cols, position = { x: 0, y: 0 }, id = `floor${index++}` }: FloorTilesProps): Entity => {
 

--- a/core/src/contrib/entities/terrain/LineWall.ts
+++ b/core/src/contrib/entities/terrain/LineWall.ts
@@ -3,26 +3,33 @@ import { Graphics } from "pixi.js";
 
 export type LineWallProps = {
   points: number[]
+  position?: { x: number, y: number }
   visible?: boolean
   health?: number
   shootable?: boolean
   id?: string
 }
 
-export const LineWall = ({ points, visible, health, id, shootable }: LineWallProps) => {
+export const LineWall = ({ points, position, visible, health, id, shootable }: LineWallProps) => {
 
-  const newPoints = points.map((point, i) => {
-    if (i % 2 === 0) {
-      return point - points[0];
-    } else {
-      return point - points[1];
-    }
-  });
+  let newPoints: number[] = [];
+
+  if (position) {
+    newPoints = points;
+  } else {
+    newPoints = points.map((point, i) => {
+      if (i % 2 === 0) {
+        return point - points[0];
+      } else {
+        return point - points[1];
+      }
+    });
+  }
 
   const wall = Entity({
     id: id ?? `linewall-${points.join("-")}`,
     components: {
-      position: new Position({ x: points[0], y: points[1] }),
+      position: new Position({ x: position?.x ?? points[0], y: position?.y ?? points[1] }),
       debug: new Debug(),
       health: new Health({ health: health ?? 9999, maxHealth: health ?? 9999, showHealthBar: false, shootable: shootable ?? false }),
       networked: new Networked({ isNetworked: true }),

--- a/core/src/contrib/entities/terrain/LineWall.ts
+++ b/core/src/contrib/entities/terrain/LineWall.ts
@@ -31,13 +31,14 @@ export const LineWall = ({ points, position, visible, health, id, shootable }: L
     components: {
       position: new Position({ x: position?.x ?? points[0], y: position?.y ?? points[1] }),
       debug: new Debug(),
-      health: new Health({ health: health ?? 9999, maxHealth: health ?? 9999, showHealthBar: false, shootable: shootable ?? false }),
+      health: new Health({ health: health ?? 9999, maxHealth: health ?? 9999, showHealthBar: false }),
       networked: new Networked({ isNetworked: true }),
       collider: new Collider({
         shape: "line",
         isStatic: true,
         points: newPoints,
-        priority: 1
+        priority: 1,
+        shootable: shootable ?? true
       }),
       renderable: new Renderable({
         visible: visible ?? false,

--- a/core/src/contrib/entities/ui/FpsText.ts
+++ b/core/src/contrib/entities/ui/FpsText.ts
@@ -15,12 +15,12 @@ export const FpsText = ({ x, y }: FpsTextProps = {}) => Entity<Position | Render
     }),
     renderable: new Renderable({
       zIndex: 3,
-      setContainer: async () => new Text({ text: "", style: { fontSize: 14, fill: "#FFFFFF" } }),
+      setContainer: async () => new Text({ text: "", style: { fontSize: 14, fill: "#00ff00" }, resolution: 2 }),
       dynamic: (t: Text, _, __, w: World) => {
         if (w.tick % 5 !== 0) return;
         if (t) {
           const fps = Math.round(w.renderer?.app.ticker.FPS ?? 0);
-          t.style.fill = fps > 100 ? "#00ff00" : fps > 60 ? "yellow" : "red";
+          // if (t.style) t.style.fill = fps > 100 ? "#00ff00" : fps > 60 ? "yellow" : "red";
           t.text = `fps: ${fps}`;
         }
       }
@@ -37,12 +37,12 @@ export const LagText = ({ x, y }: FpsTextProps = {}) => Entity<Position | Render
     }),
     renderable: new Renderable({
       zIndex: 3,
-      setContainer: async () => new Text({ text: "", style: { fontSize: 14, fill: "#FFFFFF" } }),
+      setContainer: async () => new Text({ text: "", style: { fontSize: 14, fill: "#00ff00" }, resolution: 2 }),
       dynamic: (t: Text, _, __, w: World) => {
         const lag = Math.round(w.client?.ms ?? 0);
         if (w.tick % 5 !== 0) return;
         if (t) {
-          t.style.fill = lag < 50 ? "#00ff00" : lag < 200 ? "yellow" : "red";
+          // t.style.fill = lag < 50 ? "#00ff00" : lag < 200 ? "yellow" : "red";
           t.text = `ms: ${lag}`;
         }
       }

--- a/core/src/contrib/systems/core/PhysicsSystem.ts
+++ b/core/src/contrib/systems/core/PhysicsSystem.ts
@@ -56,7 +56,7 @@ export const PhysicsSystem: SystemBuilder<"PhysicsSystem"> = {
             try {
               collider.rapierCollider = physics.createCollider(collider.colliderDesc, body);
             } catch (e) {
-              console.log("Error creating collider");
+              console.log("Error creating collider", e);
             }
 
             // set Collider.body

--- a/core/src/contrib/systems/ui/ClickableSystem.ts
+++ b/core/src/contrib/systems/ui/ClickableSystem.ts
@@ -1,4 +1,4 @@
-import { Actions, Clickable, ClientSystemBuilder, Entity, Position, boundsCheck, mouse } from "@piggo-gg/core";
+import { Actions, Clickable, ClientSystemBuilder, Entity, Position, checkBounds, mouse } from "@piggo-gg/core";
 import { FederatedPointerEvent } from "pixi.js";
 
 export type Click = { x: number, y: number };
@@ -28,7 +28,7 @@ export const ClickableSystem = ClientSystemBuilder({
           const { clickable, position } = entity.components;
   
           if (hovered.has(entity.id)) {
-            const hovering = boundsCheck(renderer, position, clickable, mouse, mouse);
+            const hovering = checkBounds(renderer, position, clickable, mouse, mouse);
             if (!hovering) {
               if (clickable.hoverOut) clickable.hoverOut();
               hovered.delete(entity.id);
@@ -36,7 +36,7 @@ export const ClickableSystem = ClientSystemBuilder({
           }
   
           if (clickable.active && clickable.hoverOver && !hovered.has(entity.id)) {
-            const hovering = boundsCheck(renderer, position, clickable, mouse, mouse);
+            const hovering = checkBounds(renderer, position, clickable, mouse, mouse);
             if (hovering) {
               clickable.hoverOver();
               hovered.add(entity.id);
@@ -51,7 +51,7 @@ export const ClickableSystem = ClientSystemBuilder({
             const { clickable, position, networked } = entity.components;
             if (!clickable.active || !clickable.click) return;
   
-            const clicked = boundsCheck(renderer, position, clickable, click, clickWorld);
+            const clicked = checkBounds(renderer, position, clickable, click, clickWorld);
             if (clicked) {
               const invocation = clickable.click();
   

--- a/core/src/contrib/systems/ui/InputSystem.ts
+++ b/core/src/contrib/systems/ui/InputSystem.ts
@@ -1,4 +1,4 @@
-import { Actions, ClientSystemBuilder, Controlled, Controller, Entity, World, currentJoystickPosition } from "@piggo-gg/core";
+import { Actions, ClientSystemBuilder, Controlled, Controller, Entity, Position, World, currentJoystickPosition } from "@piggo-gg/core";
 
 // TODO these are global dependencies
 export var chatBuffer: string[] = [];
@@ -98,7 +98,7 @@ export const InputSystem = ClientSystemBuilder({
       }
     });
 
-    const handleInputForEntity = (entity: Entity<Controlled | Controller | Actions>, world: World) => {
+    const handleInputForEntity = (entity: Entity<Controlled | Controller | Actions | Position>, world: World) => {
       // copy the input buffer
       let buffer = bufferedDown.copy();
 
@@ -107,7 +107,7 @@ export const InputSystem = ClientSystemBuilder({
 
       // handle joystick input
       if (currentJoystickPosition.power > 0.1 && controller.controllerMap.joystick) {
-        const joystickAction = controller.controllerMap.joystick();
+        const joystickAction = controller.controllerMap.joystick({ entity });
         if (joystickAction) world.actionBuffer.push(world.tick + 1, entity.id, joystickAction);
       }
 
@@ -150,17 +150,17 @@ export const InputSystem = ClientSystemBuilder({
 
     return {
       id: "InputSystem",
-      query: ["controlled", "controller", "actions"],
+      query: ["controlled", "controller", "actions", "position"],
       skipOnRollback: true,
-      onTick: (entities: Entity<Controlled | Controller | Actions>[]) => {
+      onTick: (entities: Entity<Controlled | Controller | Actions | Position>[]) => {
         // update mouse position, the camera might have moved
         if (renderer) mouse = renderer.camera.toWorldCoords(mouseEvent);
-  
+
         // handle inputs for controlled entities
         entities.forEach((entity) => {
           if (entity.components.controlled.data.entityId === world.client?.playerId) handleInputForEntity(entity, world);
         });
-  
+
         // handle buffered backspace
         if (chatIsOpen && backspaceOn && world.tick % 2 === 0) chatBuffer.pop();
       }

--- a/core/src/contrib/systems/ui/RenderSystem.ts
+++ b/core/src/contrib/systems/ui/RenderSystem.ts
@@ -76,7 +76,7 @@ export const RenderSystem = ClientSystemBuilder({
         entities.forEach((entity) => {
           const { position, renderable, controlled } = entity.components;
 
-          // cull entities that are far from the camera
+          // cull if far from camera
           if (!position.screenFixed && renderable.children) {
             renderable.children.forEach((child) => {
               if (child.c) child.visible = !isFarFromCamera({
@@ -86,13 +86,13 @@ export const RenderSystem = ClientSystemBuilder({
             });
           }
 
-          // add new entities to the renderer
+          // render if new entity
           if (!renderable.rendered) {
             renderable.rendered = true;
             renderNewEntity(entity);
           }
 
-          // center this entity if controlled by player
+          // center it if controlled by player
           if (controlled && position && centeredEntity !== entity && controlled.data.entityId === world.client?.playerId) {
             centeredEntity = entity;
           }
@@ -132,10 +132,10 @@ export const RenderSystem = ClientSystemBuilder({
 
             // set activeAnimation
             renderable.activeAnimation = renderable.bufferedAnimation;
-
             renderable.bufferedAnimation = "";
           }
 
+          // reset buffered animation
           if (renderable.bufferedAnimation === renderable.activeAnimation) {
             renderable.bufferedAnimation = "";
           }

--- a/core/src/contrib/systems/ui/RenderSystem.ts
+++ b/core/src/contrib/systems/ui/RenderSystem.ts
@@ -67,7 +67,7 @@ export const RenderSystem = ClientSystemBuilder({
 
         const { x: cameraX, y: cameraY } = centeredEntity?.components.position.data ?? { x: 0, y: 0 };
         const { width, height } = renderer.app.screen;
-        const cameraScale = renderer.camera.c.scale.x - 0.4;
+        const cameraScale = renderer.camera.c.scale.x - 0.5;
 
         const isFarFromCamera = ({ x, y }: { x: number, y: number }) => {
           return Math.abs(x - cameraX) > (width / cameraScale / 2) || Math.abs(y - cameraY) > (height / cameraScale / 2);

--- a/core/src/contrib/systems/ui/RenderSystem.ts
+++ b/core/src/contrib/systems/ui/RenderSystem.ts
@@ -73,16 +73,16 @@ export const RenderSystem = ClientSystemBuilder({
           return Math.abs(x - cameraX) > (width / cameraScale / 2) || Math.abs(y - cameraY) > (height / cameraScale / 2);
         }
 
-        const cullVisible = (p: Position, r: Renderable) => {
-          r.visible = (!isFarFromCamera({ x: p.data.x + r.position.x, y: p.data.y + r.position.y }));
-        }
-
         entities.forEach((entity) => {
           const { position, renderable, controlled } = entity.components;
 
+          // cull entities that are far from the camera
           if (!position.screenFixed && renderable.children) {
             renderable.children.forEach((child) => {
-              if (child.c) cullVisible(position, child);
+              if (child.c) child.visible = !isFarFromCamera({
+                x: position.data.x + child.position.x,
+                y: position.data.y + child.position.y
+              });
             });
           }
 

--- a/core/src/contrib/utils/GeometryUtils.ts
+++ b/core/src/contrib/utils/GeometryUtils.ts
@@ -45,8 +45,21 @@ export const getClosestEntity = (entities: Entity<Position>[], pos: { x: number,
   return entities[0];
 }
 
+export const normalize = ({ x, y, entity }: { x: number, y: number, entity: Entity<Position> }): { x: number, y: number } => {
+  const { speed } = entity.components.position.data;
 
-export const boundsCheck = (renderer: Renderer, position: Position, clickable: Clickable, click: Click, clickWorld: Click): boolean => {
+  if (x === 0) return { x, y: Math.sign(y) * speed };
+  if (y === 0) return { x: Math.sign(x) * speed, y };
+
+  const ratio = x * x / (y * y);
+
+  const newX = Math.sqrt(speed * speed / (1 + ratio)) * Math.sign(x);
+  const newY = Math.sqrt(speed * speed / (1 + 1 / ratio)) * Math.sign(y);
+
+  return { x: newX, y: newY };
+}
+
+export const checkBounds = (renderer: Renderer, position: Position, clickable: Clickable, click: Click, clickWorld: Click): boolean => {
 
   let { x, y } = position.data;
   if (clickable.anchor) {

--- a/core/src/net/DelaySyncer.ts
+++ b/core/src/net/DelaySyncer.ts
@@ -1,7 +1,4 @@
-import {
-  Ball, GameData, LineWall, Noob, Projectile, SerializedEntity,
-  Skelly, Syncer, World, Zombie
-} from "@piggo-gg/core";
+import { Ball, GameData, LineWall, Noob, Projectile, SerializedEntity, Syncer, World, Zombie } from "@piggo-gg/core";
 
 export const DelaySyncer: Syncer = {
   writeMessage: (world: World) => {
@@ -44,7 +41,7 @@ export const DelaySyncer: Syncer = {
         } else if (entityId.startsWith("noob")) {
           world.addEntity(Noob({ id: entityId }))
         } else if (entityId.startsWith("projectile")) {
-          world.addEntity(Projectile({id: entityId, radius: 3}));
+          world.addEntity(Projectile({ id: entityId, radius: 3 }));
         } else if (entityId.startsWith("linewall")) {
           const points = entityId.split("-").slice(1).map((p) => parseInt(p)).filter(Number);
           world.addEntity(LineWall({ id: entityId, points, visible: true }));

--- a/games/home/Home.ts
+++ b/games/home/Home.ts
@@ -25,6 +25,7 @@ export const Home = IsometricGame({
       FloorTiles({ rows: 7, cols: 7, position: { x: -32 * 16, y: 32 * 17 } }),
 
       LineWall({
+        shootable: false,
         points: [
           32 * -8, 32 * 4.5,
           32, 0,

--- a/games/home/Home.ts
+++ b/games/home/Home.ts
@@ -4,10 +4,10 @@ import {
   LineWall, PlayerSpawnSystem, Portal
 } from "@piggo-gg/core";
 
-export const Hubworld = IsometricGame({
-  id: "hubworld",
+export const Home = IsometricGame({
+  id: "home",
   init: () => ({
-    id: "hubworld",
+    id: "home",
     entities: [
       Background({ img: "stars.png" }),
 

--- a/games/main.ts
+++ b/games/main.ts
@@ -3,5 +3,5 @@ export * from "./legends/entities";
 export * from "./soccer/Soccer";
 export * from "./soccer/entities";
 export * from "./strike/Strike";
-export * from "./hubworld/Hubworld";
+export * from "./home/Home";
 export * from "./aram/ARAM";

--- a/games/readme.md
+++ b/games/readme.md
@@ -3,7 +3,7 @@
 |game|description|
 |--|--|
 |`aram`|all random all mid
-|`hubworld`|starting world with portals to other games
+|`home`|starting world with portals to other games
 |`legends`| team PvP MOBA
 |`soccer`|kick the ball into the goal!
 |`strike`|tactical search & destroy

--- a/games/strike/Strike.ts
+++ b/games/strike/Strike.ts
@@ -1,8 +1,6 @@
-import {
-  Background, FloorTiles,
-  GunSystem, HealthBarSystem, IsometricGame,
-  LineWall, PlayerSpawnSystem
-} from "@piggo-gg/core";
+import { Background, FloorTiles, GunSystem, HealthBarSystem, IsometricGame, LineWall, PlayerSpawnSystem } from "@piggo-gg/core";
+
+const W32 = 32;
 
 export const Strike = IsometricGame({
   id: "strike",
@@ -10,22 +8,40 @@ export const Strike = IsometricGame({
     id: "strike",
     entities: [
       Background({ img: "stars.png" }),
-      FloorTiles({ rows: 15, cols: 7, position: { x: 32 * 3, y: 32 * 6.5 }, tint: 0xff6666 }), // T
+      FloorTiles({ rows: 15, cols: 7, position: { x: W32 * 3, y: W32 * 6.5 }, tint: 0xff6666 }), // T
 
-      FloorTiles({ rows: 20, cols: 4, position: { x: 32 * 26, y: 32 * 2 } }),
-      FloorTiles({ rows: 4, cols: 16, position: { x: 32 * 30, y: 32 * 4 } }),
-      FloorTiles({ rows: 4, cols: 20, position: { x: 32 * -1, y: 32 * 15.5 } }),
+      FloorTiles({ rows: 20, cols: 4, position: { x: W32 * 26, y: W32 * 2 } }),
 
-      FloorTiles({ rows: 31, cols: 15, position: { x: 32 * 46, y: 32 * 12 } }), // mid
+      FloorTiles({ rows: 12, cols: 4, position: { x: W32 * 50, y: W32 * 2 } }),
+      FloorTiles({ rows: 4, cols: 20, position: { x: W32 * -1, y: W32 * 15.5 } }),
+      FloorTiles({ rows: 4, cols: 16, position: { x: W32 * 30, y: W32 * 4 } }),
+      FloorTiles({ rows: 4, cols: 16, position: { x: W32 * 14, y: W32 * 12 } }),
+      FloorTiles({ rows: 4, cols: 4, position: { x: W32 * 54, y: W32 * 4 } }),
 
-      FloorTiles({ rows: 12, cols: 4, position: { x: 36 * 52.9, y: 32 * 23.5 } }),
+      FloorTiles({ rows: 10, cols: 15, position: { x: W32 * 58, y: W32 * 6 }, tint: 0xffccaa }), // B
+      FloorTiles({ rows: 2, cols: 4, position: { x: W32 * 59, y: W32 * 16.5 } }),
+      FloorTiles({ rows: 2, cols: 4, position: { x: W32 * 48, y: W32 * 11 } }),
+      FloorTiles({ rows: 31, cols: 15, position: { x: W32 * 46, y: W32 * 12 } }), // mid
 
-      FloorTiles({ rows: 15, cols: 6, position: { x: 32 * 74.5, y: 32 * 20 }, tint: 0x6666ff }), // CT
-      FloorTiles({ rows: 15, cols: 10, position: { x: 32 * 47.5, y: 32 * 29.5 }, tint: 0xFFA500 }), // A
+      FloorTiles({ rows: 4, cols: 8, position: { x: W32 * 73, y: W32 * 13.5 } }),
+      FloorTiles({ rows: 9, cols: 4, position: { x: W32 * 81, y: W32 * 17.5 } }),
+      FloorTiles({ rows: 4, cols: 6, position: { x: W32 * 57, y: W32 * 21.5 } }),
+      FloorTiles({ rows: 15, cols: 6, position: { x: W32 * 70, y: W32 * 21 }, tint: 0x6666ff }), // CT
 
-      FloorTiles({ rows: 10, cols: 15, position: { x: 32 * 60, y: 32 * 5 }, tint: 0xFFA500 }), // B
+      FloorTiles({ rows: 4, cols: 2, position: { x: W32 * 34, y: W32 * 33 } }),
+      FloorTiles({ rows: 4, cols: 2, position: { x: W32 * 45, y: W32 * 27.5 } }),
+      FloorTiles({ rows: 4, cols: 4, position: { x: W32 * 57, y: W32 * 29.5 } }),
 
-      // LineWall({ points: [32, 0, 832, 400, 32, 800, -768, 400, 32, 0] })
+      FloorTiles({ rows: 15, cols: 10, position: { x: W32 * 47, y: W32 * 28.5 }, tint: 0xffccaa }), // A
+
+      LineWall({ points: [224, 384, 864, 704, 640, 816, 0, 496, 224, 384] }),
+      LineWall({ points: [-352, 448, 128, 208, 128, 208, 352, 320, 864, 64, 1248, 256, 1632, 64, 2752, 624, 1376, 1312, -352, 448] }),
+      LineWall({ points: [864, 192, 1376, 448, 992, 640, 480, 384, 864, 192] }),
+      LineWall({ points: [1376, 320, 1504, 384, 1760, 256, 1632, 192, 1376, 320] }),
+      LineWall({ points: [1920, 528, 1856, 560, 1632, 448, 1696, 416, 1920, 528] }),
+      LineWall({ points: [2048, 784, 1856, 688, 2240, 496, 2496, 624, 2336, 704, 2272, 672, 2048, 784] }),
+      LineWall({ points: [1120, 1056, 1344, 944, 1408, 976, 1184, 1088, 1120, 1056] }),
+      LineWall({ points: [1856, 944, 1728, 1008, 1472, 880, 1728, 752, 1920, 848, 1792, 912, 1856, 944] }),
     ],
     systems: [PlayerSpawnSystem, HealthBarSystem, GunSystem],
   })

--- a/games/strike/Strike.ts
+++ b/games/strike/Strike.ts
@@ -7,7 +7,7 @@ export const Strike = IsometricGame({
   init: () => ({
     id: "strike",
     entities: [
-      Background({ img: "stars.png" }),
+      Background(),
       FloorTiles({ rows: 15, cols: 7, position: { x: W32 * 3, y: W32 * 6.5 }, tint: 0xff6666 }), // T
 
       FloorTiles({ rows: 20, cols: 4, position: { x: W32 * 26, y: W32 * 2 } }),
@@ -35,7 +35,7 @@ export const Strike = IsometricGame({
       FloorTiles({ rows: 15, cols: 10, position: { x: W32 * 47, y: W32 * 28.5 }, tint: 0xffccaa }), // A
 
       LineWall({ points: [224, 384, 864, 704, 640, 816, 0, 496, 224, 384] }),
-      LineWall({ points: [-352, 448, 128, 208, 128, 208, 352, 320, 864, 64, 1248, 256, 1632, 64, 2752, 624, 1376, 1312, -352, 448] }),
+      LineWall({ shootable: false, points: [-352, 448, 128, 208, 128, 208, 352, 320, 864, 64, 1248, 256, 1632, 64, 2752, 624, 1376, 1312, -352, 448] }),
       LineWall({ points: [864, 192, 1376, 448, 992, 640, 480, 384, 864, 192] }),
       LineWall({ points: [1376, 320, 1504, 384, 1760, 256, 1632, 192, 1376, 320] }),
       LineWall({ points: [1920, 528, 1856, 560, 1632, 448, 1696, 416, 1920, 528] }),

--- a/games/strike/Strike.ts
+++ b/games/strike/Strike.ts
@@ -1,5 +1,5 @@
 import {
-  Background, EnemySpawnSystem, FloorTiles,
+  Background, FloorTiles,
   GunSystem, HealthBarSystem, IsometricGame,
   LineWall, PlayerSpawnSystem
 } from "@piggo-gg/core";
@@ -10,9 +10,23 @@ export const Strike = IsometricGame({
     id: "strike",
     entities: [
       Background({ img: "stars.png" }),
-      FloorTiles({ rows: 25, cols: 25 }),
-      LineWall({ points: [32, 0, 832, 400, 32, 800, -768, 400, 32, 0] })
+      FloorTiles({ rows: 15, cols: 7, position: { x: 32 * 3, y: 32 * 6.5 }, tint: 0xff6666 }), // T
+
+      FloorTiles({ rows: 20, cols: 4, position: { x: 32 * 26, y: 32 * 2 } }),
+      FloorTiles({ rows: 4, cols: 16, position: { x: 32 * 30, y: 32 * 4 } }),
+      FloorTiles({ rows: 4, cols: 20, position: { x: 32 * -1, y: 32 * 15.5 } }),
+
+      FloorTiles({ rows: 31, cols: 15, position: { x: 32 * 46, y: 32 * 12 } }), // mid
+
+      FloorTiles({ rows: 12, cols: 4, position: { x: 36 * 52.9, y: 32 * 23.5 } }),
+
+      FloorTiles({ rows: 15, cols: 6, position: { x: 32 * 74.5, y: 32 * 20 }, tint: 0x6666ff }), // CT
+      FloorTiles({ rows: 15, cols: 10, position: { x: 32 * 47.5, y: 32 * 29.5 }, tint: 0xFFA500 }), // A
+
+      FloorTiles({ rows: 10, cols: 15, position: { x: 32 * 60, y: 32 * 5 }, tint: 0xFFA500 }), // B
+
+      // LineWall({ points: [32, 0, 832, 400, 32, 800, -768, 400, 32, 0] })
     ],
-    systems: [PlayerSpawnSystem, HealthBarSystem, EnemySpawnSystem, GunSystem],
+    systems: [PlayerSpawnSystem, HealthBarSystem, GunSystem],
   })
 })

--- a/server/src/PiggoApi.ts
+++ b/server/src/PiggoApi.ts
@@ -62,7 +62,7 @@ export class PiggoApi {
 
   handleClose = (ws: ServerWebSocket<PerClientData>) => {
     const world = this.worlds[ws.data.worldId];
-    world.handleClose(ws);
+    if (world) world.handleClose(ws);
 
     delete this.clients[ws.data.id];
   }
@@ -96,7 +96,7 @@ export class PiggoApi {
     }
 
     const world = this.worlds[ws.data.worldId];
-    world.handleMessage(ws, wsData);
+    if (world) world.handleMessage(ws, wsData);
   }
 }
 

--- a/server/src/WorldManager.ts
+++ b/server/src/WorldManager.ts
@@ -1,5 +1,5 @@
 import { NetServerSystem, NetMessageTypes, IsometricWorld, Noob, World } from "@piggo-gg/core";
-import { ARAM, Hubworld, Legends, Soccer, Strike } from "@piggo-gg/games";
+import { ARAM, Home, Legends, Soccer, Strike } from "@piggo-gg/games";
 import { PerClientData } from "@piggo-gg/server";
 import { ServerWebSocket } from "bun";
 
@@ -19,7 +19,7 @@ export type WorldManagerProps = {
 
 export const WorldManager = ({ clients = {} }: WorldManagerProps = {}): WorldManager => {
 
-  const world = IsometricWorld({ runtimeMode: "server", games: [Hubworld, Strike, ARAM, Soccer, Legends] });
+  const world = IsometricWorld({ runtimeMode: "server", games: [Home, Strike, ARAM, Soccer, Legends] });
   const latestClientMessages: Record<string, { td: NetMessageTypes, latency: number }[]> = {};
 
   world.systems = {

--- a/web/src/components/GameCanvas.tsx
+++ b/web/src/components/GameCanvas.tsx
@@ -1,5 +1,5 @@
 import { IsometricWorld, Renderer, World, isMobile } from "@piggo-gg/core";
-import { ARAM, Hubworld, Legends, Soccer, Strike } from "@piggo-gg/games";
+import { ARAM, Home, Legends, Soccer, Strike } from "@piggo-gg/games";
 import React, { useEffect } from "react";
 
 export type GameCanvasProps = {
@@ -22,7 +22,7 @@ export const GameCanvas = ({ setWorld }: GameCanvasProps) => {
     const renderer = new Renderer({ canvas, width, height });
 
     renderer.init().then(() => {
-      const world = IsometricWorld({ renderer, runtimeMode: "client", games: [Strike, ARAM, Soccer, Legends] });
+      const world = IsometricWorld({ renderer, runtimeMode: "client", games: [Home, Strike, ARAM, Soccer, Legends] });
       setWorld(world);
     })
   }, []);

--- a/web/src/components/GameCanvas.tsx
+++ b/web/src/components/GameCanvas.tsx
@@ -22,7 +22,7 @@ export const GameCanvas = ({ setWorld }: GameCanvasProps) => {
     const renderer = new Renderer({ canvas, width, height });
 
     renderer.init().then(() => {
-      const world = IsometricWorld({ renderer, runtimeMode: "client", games: [Hubworld, Strike, ARAM, Soccer, Legends] });
+      const world = IsometricWorld({ renderer, runtimeMode: "client", games: [Strike, ARAM, Soccer, Legends] });
       setWorld(world);
     })
   }, []);

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -22,7 +22,7 @@ export const Header = ({ world, netState, setNetState }: HeaderProps) => (
     </h1>
     <div style={{ position: 'absolute', right: 0, bottom: 0 }}>
       <span style={{ fontFamily: "sans-serif", fontSize: 14, marginRight: 5, verticalAlign: "-70%" }}>
-        v<b>0.5.3</b>
+        v<b>0.5.4</b>
       </span>
       <a style={{ margin: 0, color: "inherit", textDecoration: "none" }} target="_blank" href="https://discord.gg/VfFG9XqDpJ">
         <FaDiscord size={20} style={{ color: "white", verticalAlign: "-80%" }}></FaDiscord>


### PR DESCRIPTION
- updated the Strike map
- added global culling (for child renderables) in `RenderSystem`
- removed `RenderSystem.cache`
- using pixi `Container.renderable` instead of `Container.visible` see [this thread](https://www.html5gamedevs.com/topic/31540-how-to-cull-objects-out-of-camera-view/)
- upgraded [rapier](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md)

![Screenshot 2024-05-08 at 1 04 23 PM](https://github.com/alexanderclarktx/piggo-gg/assets/9264428/53e9734f-382e-40f4-b645-8251f726eb5b)
