### PR TITLE
collision jitter hotfix

### DIFF
--- a/core/src/contrib/components/Position.ts
+++ b/core/src/contrib/components/Position.ts
@@ -15,6 +15,7 @@ export class Position extends Component<"position"> {
   type: "position" = "position";
 
   ortho = 0;
+  lastCollided: number = 0;
 
   override data = {
     x: 0,

--- a/core/src/contrib/systems/core/PhysicsSystem.ts
+++ b/core/src/contrib/systems/core/PhysicsSystem.ts
@@ -87,10 +87,20 @@ export const PhysicsSystem: SystemBuilder<"PhysicsSystem"> = {
           const body = bodies[id];
           const entity = world.entities[id] as Entity<Position>;
 
-          entity.components.position.data.x = Math.round(body.translation().x * 100) / 100;
-          entity.components.position.data.y = Math.round(body.translation().y * 100) / 100;
-          entity.components.position.data.velocityX = Math.floor(body.linvel().x * 100) / 100;
-          entity.components.position.data.velocityY = Math.floor(body.linvel().y * 100) / 100;
+          const { position } = entity.components;
+
+          // check if the entity has collided
+          const diffX = position.data.velocityX - Math.floor(body.linvel().x * 100) / 100;
+          const diffY = position.data.velocityY - Math.floor(body.linvel().y * 100) / 100;
+          if (Math.abs(diffX) > 1 || Math.abs(diffY) > 1) {
+            position.lastCollided = world.tick;
+          }
+
+          // update the entity position/velocity
+          position.data.x = Math.round(body.translation().x * 100) / 100;
+          position.data.y = Math.round(body.translation().y * 100) / 100;
+          position.data.velocityX = Math.floor(body.linvel().x * 100) / 100;
+          position.data.velocityY = Math.floor(body.linvel().y * 100) / 100;
         });
 
         // sensor callbacks

--- a/core/src/contrib/systems/ui/RenderSystem.ts
+++ b/core/src/contrib/systems/ui/RenderSystem.ts
@@ -163,19 +163,23 @@ export const RenderSystem = ClientSystemBuilder({
 
           const { x, y, velocityX, velocityY } = position.data;
 
+          if (centeredEntity && entity.id === centeredEntity.id) {
+            renderer.camera.moveTo({ x, y });
+          }
+
           const dx = velocityX * elapsedTime / 1000;
           const dy = velocityY * elapsedTime / 1000;
 
           // calculate interpolation with deltaMS
-          if (velocityX || velocityY) {
+          if (((world.tick - position.lastCollided) > 4) && (velocityX || velocityY)) {
             renderable.c.position.set(
               x + dx + renderable.position.x,
               y + dy + renderable.position.y
             );
-          }
 
-          if (centeredEntity && entity.id === centeredEntity.id) {
-            renderer.camera.moveTo({ x: x + dx, y: y + dy });
+            if (centeredEntity && entity.id === centeredEntity.id) {
+              renderer.camera.moveTo({ x: x + dx, y: y + dy });
+            }
           }
         });
 


### PR DESCRIPTION
on collision (with zombie or walls) there was jitter because of interpolation. disabled interpolation for entities that have recently collided with something 