### PR TITLE
[wip] better tile colliders

### DIFF
--- a/core/src/ecs/entities/terrain/FloorTiles.ts
+++ b/core/src/ecs/entities/terrain/FloorTiles.ts
@@ -1,4 +1,4 @@
-import { Collider, Entity, Position, Renderable, Renderer, TeamColors, XY } from "@piggo-gg/core";
+import { Collider, Entity, LineWall, Position, Renderable, Renderer, TeamColors, XY, equalsXY, randomColor } from "@piggo-gg/core";
 import { Container, Graphics, Matrix, RenderTexture, Sprite } from "pixi.js";
 
 export type FloorTilesProps = {
@@ -14,7 +14,7 @@ let index = 0;
 
 const width = 64;
 const height = 32;
-const tileCoordinates = [ 0, 0, width / 2, height / 2, width, 0, width / 2, -height / 2, 0, 0 ]
+const tileCoordinates = [0, 0, width / 2, height / 2, width, 0, width / 2, -height / 2, 0, 0]
 
 export const FloorTiles = ({ color, tint, rows, cols, position = { x: 0, y: 0 }, id = `floor${index++}` }: FloorTilesProps): Entity => Entity({
   id: id,
@@ -99,38 +99,212 @@ export const FloorTilesArray = (dim: number, tileArray: number[]): Entity => Ent
 })
 
 export const FloorCollidersArray = (dim: number, tileArray: number[]): Entity[] => {
+
+  const width = 64;
+  const height = 32;
+
+  let coords: number[][] = [];
+
   const entities: Entity[] = [];
   for (let x = 0; x < dim; x++) {
     for (let y = 0; y < dim; y++) {
 
       const value = tileArray[x * dim + y];
+      if (value !== 0) continue;
+
       const value9 = tileArray[x * dim + y + 1];
       const value5 = tileArray[x * dim + y - 1];
       const value7 = tileArray[(x - 1) * dim + y];
       const value1 = tileArray[(x + 1) * dim + y];
 
-      if (value !== 0) continue;
+      const pos = { x: y * width / 2 - (x * width / 2), y: (y + x) * height / 2 + 16 };
 
-      if (value9 || value5 || value7 || value1) {
-        const width = 64;
-        const height = 32;
+      if (value5) {
+        const points = [width / 2, -height / 2, 0, 0];
+        // const points = [0, 0, width / 2, -height / 2];
+        coords.push(points.map((p, i) => i % 2 === 0 ? p + pos.x : p + pos.y));
         const entity = Entity({
-          id: `floorCollider-${x}-${y}`,
+          id: `floorCollider-${x}-${y}-v5`,
           components: {
-            position: Position({
-              x: y * width / 2 - (x * width / 2),
-              y: (y + x) * height / 2 + 16
-            }),
-            collider: Collider({
-              shape: "line",
-              isStatic: true,
-              points: tileCoordinates
-            })
+            position: Position(pos),
+            collider: Collider({ shape: "line", isStatic: true, points })
           }
         });
-        entities.push(entity);
+        // entities.push(entity);
       }
+      if (value9) {
+        // const points = [width / 2, height / 2, width, 0];
+        const points = [width, 0, width / 2, height / 2];
+        coords.push(points.map((p, i) => i % 2 === 0 ? p + pos.x : p + pos.y));
+        const entity = Entity({
+          id: `floorCollider-${x}-${y}-v9`,
+          components: {
+            position: Position(pos),
+            collider: Collider({ shape: "line", isStatic: true, points })
+          }
+        });
+        // entities.push(entity);
+      }
+      if (value1) {
+        const points = [0, 0, width / 2, height / 2];
+        // const points = [width / 2, height / 2, 0, 0];
+        coords.push(points.map((p, i) => i % 2 === 0 ? p + pos.x : p + pos.y));
+        const entity = Entity({
+          id: `floorCollider-${x}-${y}-v1`,
+          components: {
+            position: Position(pos),
+            collider: Collider({ shape: "line", isStatic: true, points })
+          }
+        });
+        // entities.push(entity);
+      }
+      if (value7) {
+        // const points = [width, 0, width / 2, -height / 2];
+        const points = [width / 2, -height / 2, width, 0];
+        coords.push(points.map((p, i) => i % 2 === 0 ? p + pos.x : p + pos.y));
+        const entity = Entity({
+          id: `floorCollider-${x}-${y}-v7`,
+          components: {
+            position: Position(pos),
+            collider: Collider({ shape: "line", isStatic: true, points })
+          }
+        });
+        // entities.push(entity);
+      }
+
+
+      // entities.push(Entity({
+      //   id: `floorCollider-${x}-${y}=zzz`,
+      //   components: {
+      //     position: Position(pos),
+      //     collider: Collider({ shape: "line", isStatic: true, points: [...newPoints].flat() })
+      //   }
+      // }));
     };
   }
+
+
+
+  let lines: Set<[XY, XY]> = new Set();
+  let perimeters: Set<number[]> = new Set();
+
+  coords.forEach((c) => {
+    lines.add([{ x: c[0], y: c[1] }, { x: c[2], y: c[3] }]);
+  });
+
+
+
+  /*
+             .
+         .       .
+      <             >
+         .       .
+             .
+  */
+
+  const seenPoints: Set<XY> = new Set();
+
+  // find all the perimeter lines
+  for (const line of lines) {
+    if (!seenPoints.has(line[0]) && !seenPoints.has(line[1])) {
+      let perimeter: number[] = [line[0].x, line[0].y, line[1].x, line[1].y];
+
+      seenPoints.add(line[0]);
+      let cursor = line[1];
+
+      for (const unseenLine of lines) {
+        if (!equalsXY(unseenLine[0], line[0]) && seenPoints.has(unseenLine[0])) continue;
+        if (equalsXY(cursor, unseenLine[0])) {
+          perimeter.push(unseenLine[1].x, unseenLine[1].y);
+          seenPoints.add(unseenLine[1]);
+          cursor = unseenLine[1];
+        } else if (equalsXY(cursor, unseenLine[1]) && !seenPoints.has(unseenLine[0])) {
+          perimeter.push(unseenLine[0].x, unseenLine[0].y);
+          seenPoints.add(unseenLine[0]);
+          cursor = unseenLine[0];
+        }
+      }
+      // if (perimeter.length > 6) {
+      perimeters.add(perimeter);
+      //   seenPoints.add(line[0]);
+      // }
+    }
+  }
+
+  let cornerPerimeters: number[][] = [];
+
+  // remove unnecessary inner lines from each perimeter
+  perimeters.forEach((p) => {
+    // a corner is a point where the two lines share X or Y coordinates
+    const pointz: [number, number][] = [];
+
+    for (let i = 0; i < p.length; i += 2) {
+      pointz.push([p[i], p[i + 1]]);
+    }
+
+    const corners: [number, number][] = [];
+
+    for (let i = 0; i < pointz.length; i++) {
+      const a = pointz[i];
+      const b = pointz[(i + 1) % pointz.length];
+      const c = pointz[(i + 2) % pointz.length];
+
+      if (a[0] === c[0] || a[1] === c[1]) {
+        corners.push(b);
+      }
+    }
+
+    // connect the corners
+    // let connectedCorners: number[] = [];
+    // for (let i = 0; i < corners.length; i++) {
+    //   connectedCorners.push(corners[i][0], corners[i][1]);
+    //   connectedCorners.push(corners[(i + 1) % corners.length][0], corners[(i + 1) % corners.length][1]);
+    // }
+
+    cornerPerimeters.push(corners.flat());
+  });
+
+  console.log(perimeters);
+  console.log(cornerPerimeters);
+
+  // entities.push(Entity({
+  //   id: `floorCollider-xd`,
+  //   components: {
+  //     position: Position(),
+  //     collider: Collider({ shape: "line", isStatic: true, points: coords.flat() })
+  //   }
+  // }));
+
+  perimeters.forEach((p) => {
+    entities.push(LineWall({
+      points: p,
+      visible: true,
+      color: randomColor()
+    }));
+    // entities.push(Entity({
+    //   id: `floorCollider-${p.flat()}`,
+    //   components: {
+    //     position: Position(),
+    //     collider: Collider({ shape: "line", isStatic: true, points: p })
+    //   }
+    // }));
+  });
+
+
+  // cornerPerimeters.forEach((p) => {
+  //   if (!p.length) return;
+  //   entities.push(Entity({
+  //     id: `floorCollider-${p.flat()}`,
+  //     components: {
+  //       position: Position(),
+  //       collider: Collider({ shape: "line", isStatic: true, points: p })
+  //     }
+  //   }));
+  // });
+
+  // console.log(coords);
+
+
+
   return entities;
 }

--- a/core/src/ecs/entities/terrain/LineWall.ts
+++ b/core/src/ecs/entities/terrain/LineWall.ts
@@ -8,9 +8,10 @@ export type LineWallProps = {
   health?: number
   shootable?: boolean
   id?: string
+  color?: number
 }
 
-export const LineWall = ({ points, position, visible, health, id, shootable }: LineWallProps) => {
+export const LineWall = ({ points, position, visible, color, health, id, shootable }: LineWallProps) => {
 
   let newPoints: number[] = [];
 
@@ -54,7 +55,7 @@ export const LineWall = ({ points, position, visible, health, id, shootable }: L
           for (let i = 2; i < newPoints.length; i += 2) {
             g.lineTo(newPoints[i], newPoints[i + 1]);
           }
-          g.stroke({ width: 2, color: 0xffffff });
+          g.stroke({ width: 2, color: color ?? 0xffffff });
           return g;
         }
       })

--- a/core/src/ecs/systems/ui/DebugSystem.ts
+++ b/core/src/ecs/systems/ui/DebugSystem.ts
@@ -1,4 +1,4 @@
-import { ClientSystemBuilder, DebugBounds, Entity, FpsText, LagText, Position, Renderable, TextBox, entries, physics, values } from "@piggo-gg/core";
+import { ClientSystemBuilder, DebugBounds, Entity, FpsText, LagText, Position, Renderable, TextBox, entries, physics, randomColor, values } from "@piggo-gg/core";
 import { Graphics, Text } from "pixi.js";
 
 // DebugSystem adds visual debug information to renderered entities
@@ -71,16 +71,20 @@ export const DebugSystem = ClientSystemBuilder({
       const r = Renderable({
         dynamic: (c: Graphics) => {
           if (c.clear) {
-            c.clear().setStrokeStyle({ width: 1, color: 0xffff00 });
             const { vertices } = physics.debugRender();
 
+            c.clear().setStrokeStyle({ width: 4 });
+
+            let color = 0xff0000;
+
             for (let i = 0; i < vertices.length; i += 4) {
+              color = color === 0xff0000 ? 0x00ff00 : 0xff0000;
               const one = { x: vertices[i], y: vertices[i + 1] };
               const two = { x: vertices[i + 2], y: vertices[i + 3] };
               c.moveTo(one.x, one.y);
               c.lineTo(two.x, two.y);
+              c.stroke({ color });
             }
-            c.stroke();
           }
         },
         zIndex: 5,
@@ -111,19 +115,19 @@ export const DebugSystem = ClientSystemBuilder({
           // handle new entities
           entities.forEach((entity) => {
             const { renderable } = entity.components;
-  
+
             if (!debugEntitiesPerEntity[entity.id] || !debugEntitiesPerEntity[entity.id].length) {
               debugEntitiesPerEntity[entity.id] = [];
               if (renderable) addEntityForRenderable(entity as Entity<Renderable | Position>);
             }
           });
-  
+
           // draw all colliders
           if (!world.entities["collider-debug"]) drawAllColliders();
-  
+
           // draw the fps text
           if (!world.entities["fpsText"]) drawFpsText();
-  
+
           // update all debug entities
           entries(debugEntitiesPerEntity).forEach(([id, debugEntities]) => {
             const entity = world.entities[id] as Entity<Position>;
@@ -146,7 +150,7 @@ export const DebugSystem = ClientSystemBuilder({
             debugEntities.forEach((debugEntity) => world.removeEntity(debugEntity.id));
           });
           debugEntitiesPerEntity = {};
-  
+
           // clear debug renderables
           debugRenderables = [];
         }

--- a/core/src/utils/MathUtils.ts
+++ b/core/src/utils/MathUtils.ts
@@ -2,6 +2,8 @@ import { Clickable, Entity, Position, Renderer } from "@piggo-gg/core";
 
 export type XY = { x: number, y: number };
 
+export const equalsXY = (a: XY, b: XY) => a.x === b.x && a.y === b.y;
+
 export const orthoToDirection = (o: number) => {
   if (o === 0) return "l";
   if (o === 1) return "ul";
@@ -92,3 +94,5 @@ export const checkBounds = (renderer: Renderer, position: Position, clickable: C
 
   return clicked;
 }
+
+export const randomColor = () => Math.random() * 0xffffff;


### PR DESCRIPTION
[ PR on hold because it's a difficult change and low priority ]

Currently the tile colliders are generated by creating a square for every "empty" tile. This leads to "bumpy" walls if a player moves across it. The colliders need to instead be continuous lines from corner to corner 

the code in this PR does not 100% work yet