### PR TITLE
v0.6.17 fullscreen minimap

### DIFF
--- a/core/src/ecs/entities/characters/Skelly.ts
+++ b/core/src/ecs/entities/characters/Skelly.ts
@@ -12,7 +12,7 @@ export const Skelly = (id: string, team: TeamNumber, color?: number, pos?: XY) =
     id: id,
     components: {
       debug: Debug(),
-      position: Position({ x: pos?.x ?? 32, y: pos?.y ?? 400, velocityResets: 1, speed: 160 }),
+      position: Position({ x: pos?.x ?? 32, y: pos?.y ?? 400, velocityResets: 1, speed: 140 }),
       networked: Networked({ isNetworked: true }),
       collider: Collider({ shape: "ball", radius: 8, mass: 600, shootable: true }),
       health: Health({ health: 200, maxHealth: 200 }),

--- a/core/src/ecs/entities/characters/Spaceship.ts
+++ b/core/src/ecs/entities/characters/Spaceship.ts
@@ -26,8 +26,7 @@ export const Spaceship = ({ id, position }: SpaceshipProps = {}) => Entity({
         "s": ({ world }) => ({ action: "down", playerId: world.client?.playerId() }),
         "a": ({ world }) => ({ action: "left", playerId: world.client?.playerId() }),
         "d": ({ world }) => ({ action: "right", playerId: world.client?.playerId() })
-      },
-      joystick: () => null
+      }
     }),
     debug: Debug(),
     renderable: Renderable({

--- a/core/src/ecs/entities/objects/Projectile.ts
+++ b/core/src/ecs/entities/objects/Projectile.ts
@@ -50,7 +50,7 @@ export const Projectile = ({ radius, pos, id, color, onHit = onHitDefault }: Pro
         zIndex: 3,
         interpolate: true,
         setContainer: async () => {
-          return pixiCircle({ x: 0, y: 0, r: radius ?? 8, style: { color, alpha: 1 } });
+          return pixiCircle({ x: 0, y: 0, r: radius ?? 8, style: { color, alpha: 1, strokeColor: 0x000000, strokeWidth: 1, strokeAlpha: 0.5 } });
         }
       })
     }

--- a/core/src/ecs/entities/terrain/FloorTiles.ts
+++ b/core/src/ecs/entities/terrain/FloorTiles.ts
@@ -14,7 +14,7 @@ let index = 0;
 
 const width = 64;
 const height = 32;
-const tileCoordinates = [ 0, 0, width / 2, height / 2, width, 0, width / 2, -height / 2, 0, 0 ]
+const tileCoordinates = [0, 0, width / 2, height / 2, width, 0, width / 2, -height / 2, 0, 0]
 
 export const FloorTilesArray = (dim: number, tileMap: number[]): Entity => Entity({
   id: "floorTilesArray",
@@ -64,38 +64,54 @@ export const FloorTilesArray = (dim: number, tileMap: number[]): Entity => Entit
 
 export const FloorCollidersArray = (dim: number, tileMap: number[]): Entity[] => {
   const entities: Entity[] = [];
+  let coords: number[][] = [];
+
   for (let x = 0; x < dim; x++) {
     for (let y = 0; y < dim; y++) {
 
       const value = tileMap[x * dim + y];
+      if (value !== 0) continue;
+
       const value9 = tileMap[x * dim + y + 1];
       const value5 = tileMap[x * dim + y - 1];
       const value7 = tileMap[(x - 1) * dim + y];
       const value1 = tileMap[(x + 1) * dim + y];
 
-      if (value !== 0) continue;
+      const pos = { x: y * width / 2 - (x * width / 2), y: (y + x) * height / 2 + 16 };
+      const adjustedPos = (p: number, i: number) => i % 2 === 0 ? p + pos.x : p + pos.y;
 
-      if (value9 || value5 || value7 || value1) {
-        const width = 64;
-        const height = 32;
-        const entity = Entity({
-          id: `floorCollider-${x}-${y}`,
-          components: {
-            position: Position({
-              x: y * width / 2 - (x * width / 2),
-              y: (y + x) * height / 2 + 16
-            }),
-            collider: Collider({
-              shape: "line",
-              isStatic: true,
-              points: tileCoordinates
-            })
-          }
-        });
-        entities.push(entity);
+      if (value5) {
+        const points = [width / 2, -height / 2, 0, 0];
+        coords.push(points.map(adjustedPos));
       }
-    };
+
+      if (value9) {
+        const points = [width, 0, width / 2, height / 2];
+        coords.push(points.map(adjustedPos));
+      }
+
+      if (value1) {
+        const points = [0, 0, width / 2, height / 2];
+        coords.push(points.map(adjustedPos));
+      }
+
+      if (value7) {
+        const points = [width / 2, -height / 2, width, 0];
+        coords.push(points.map(adjustedPos));
+      }
+    }
   }
+
+  coords.forEach((points, i) => {
+    entities.push(Entity({
+      id: `floorCollider-${i}`,
+      components: {
+        position: Position(),
+        collider: Collider({ shape: "line", isStatic: true, points })
+      }
+    }));
+  });
+
   return entities;
 }
 

--- a/core/src/ecs/entities/ui/Minimap.ts
+++ b/core/src/ecs/entities/ui/Minimap.ts
@@ -1,11 +1,18 @@
-import { Entity, Position, Renderable, TeamColors } from "@piggo-gg/core";
+import { Action, Actions, Entity, Input, Position, Renderable, TeamColors } from "@piggo-gg/core";
 import { Container, Graphics } from "pixi.js";
 
 export const Minimap = (dim: number, tileMap: number[]): Entity => {
   const container = new Container();
-  const tileGraphics = new Graphics({ alpha: 0.9, rotation: Math.PI / 4 });
-
   let scale = 0.5;
+
+  const tileGraphics = new Graphics({ alpha: 0.9, rotation: Math.PI / 4 });
+  const background = new Graphics();
+  background.circle(0, 0, 100).fill({ color: 0x000000, alpha: 0.4 });
+  const outline = new Graphics();
+  outline.circle(0, 0, 100).stroke({ color: 0xffffff, width: 2, alpha: 0.9 });
+  const mask = background.clone();
+
+  let fs = false;
 
   const Colors: Record<number, number> = {
     37: TeamColors[1],
@@ -13,10 +20,33 @@ export const Minimap = (dim: number, tileMap: number[]): Entity => {
     19: 0xffccaa
   }
 
-  const minimap = Entity({
+  const minimap = Entity<Position | Renderable>({
     id: "minimap",
     components: {
       position: Position({ x: -125, y: 125, screenFixed: true }),
+      input: Input({
+        press: { "capslock": ({ world }) => ({ action: "toggleFS", playerId: world.client?.playerId() }) }
+      }),
+      actions: Actions({
+        toggleFS: Action(({ world }) => {
+          if (fs) {
+            minimap.components.position = Position({ x: -125, y: 125, screenFixed: true });
+            tileGraphics.mask = mask;
+            tileGraphics.scale = 1;
+            background.circle(0, 0, 100).fill({ color: 0x000000, alpha: 0.4 });
+            outline.circle(0, 0, 100).stroke({ color: 0xffffff, width: 2, alpha: 0.9 });
+          } else {
+            const x = (world.renderer?.app.canvas.width ?? 0) / 2;
+            const y = (world.renderer?.app.canvas.height ?? 0) / 2;
+            minimap.components.position = Position({ x, y, screenFixed: true });
+            tileGraphics.mask = null;
+            background.clear();
+            outline.clear();
+            tileGraphics.scale = 2;
+          }
+          fs = !fs;
+        }),
+      }),
       renderable: Renderable({
         zIndex: 10,
         dynamic: (_, __, ___, w) => {
@@ -31,17 +61,7 @@ export const Minimap = (dim: number, tileMap: number[]): Entity => {
           tileGraphics.position.set(-position.data.x / 5.6 * scale + 5, - position.data.y / 2.8 * scale + 2);
         },
         setContainer: async () => {
-
-          // background
-          const background = new Graphics();
-          background.circle(0, 0, 100).fill({ color: 0x000000, alpha: 0.4 })
-
-          // outline
-          const outline = new Graphics();
-          outline.circle(0, 0, 100).stroke({ color: 0xffffff, width: 2, alpha: 0.9 });
-
           // mask
-          const mask = background.clone();
           tileGraphics.mask = mask;
 
           // player dot
@@ -51,6 +71,8 @@ export const Minimap = (dim: number, tileMap: number[]): Entity => {
           // draw the tiles
           const width = 8 * scale;
           let color = 0xccccff
+
+          // draw the tiles
           tileMap.forEach((tile, i) => {
             if (tile === 0) return;
 

--- a/core/src/ecs/entities/ui/Minimap.ts
+++ b/core/src/ecs/entities/ui/Minimap.ts
@@ -2,17 +2,17 @@ import { Action, Actions, Entity, Input, Position, Renderable, TeamColors } from
 import { Container, Graphics } from "pixi.js";
 
 export const Minimap = (dim: number, tileMap: number[]): Entity => {
-  const container = new Container();
   let scale = 0.5;
+  let fullscreen = false;
 
+  const container = new Container();
   const tileGraphics = new Graphics({ alpha: 0.9, rotation: Math.PI / 4 });
   const background = new Graphics();
-  background.circle(0, 0, 100).fill({ color: 0x000000, alpha: 0.4 });
-  const outline = new Graphics();
-  outline.circle(0, 0, 100).stroke({ color: 0xffffff, width: 2, alpha: 0.9 });
   const mask = background.clone();
+  const outline = new Graphics();
 
-  let fs = false;
+  background.circle(0, 0, 100).fill({ color: 0x000000, alpha: 0.4 });  
+  outline.circle(0, 0, 100).stroke({ color: 0xffffff, width: 2, alpha: 0.9 });
 
   const Colors: Record<number, number> = {
     37: TeamColors[1],
@@ -29,7 +29,7 @@ export const Minimap = (dim: number, tileMap: number[]): Entity => {
       }),
       actions: Actions({
         toggleFS: Action(({ world }) => {
-          if (fs) {
+          if (fullscreen) {
             minimap.components.position = Position({ x: -125, y: 125, screenFixed: true });
             tileGraphics.mask = mask;
             tileGraphics.scale = 1;
@@ -44,7 +44,7 @@ export const Minimap = (dim: number, tileMap: number[]): Entity => {
             outline.clear();
             tileGraphics.scale = 2;
           }
-          fs = !fs;
+          fullscreen = !fullscreen;
         }),
       }),
       renderable: Renderable({

--- a/core/src/ecs/entities/ui/Scoreboard.ts
+++ b/core/src/ecs/entities/ui/Scoreboard.ts
@@ -3,7 +3,7 @@ import { ScrollBox } from "@pixi/ui";
 import { Container, Graphics } from "pixi.js";
 
 export const Scoreboard = (): Entity => {
-  let players: Set<{name: string, entity: Noob}> = new Set();
+  let players: Set<{ name: string, entity: Noob }> = new Set();
   let team1: ScrollBox;
   let team2: ScrollBox;
   let width: number;
@@ -11,17 +11,12 @@ export const Scoreboard = (): Entity => {
   const scoreboard = Entity<Position>({
     id: "scoreboard",
     components: {
+      position: Position({ x: 200, y: 200, screenFixed: true }),
       input: Input({
-        press: {
-          "shift": ({ world }) => ({ action: "ToggleVisible", playerId: world.client?.playerId() })
-        },
-        release: {
-          "shift": ({ world }) => ({ action: "ToggleHidden", playerId: world.client?.playerId() })
-        },
-        joystick: () => null
+        press: { "shift": ({ world }) => ({ action: "ToggleVisible", playerId: world.client?.playerId() }) },
+        release: { "shift": ({ world }) => ({ action: "ToggleHidden", playerId: world.client?.playerId() }) }
       }),
       actions: Actions({ ToggleVisible, ToggleHidden }),
-      position: Position({ x: 200, y: 200, screenFixed: true }),
       renderable: Renderable({
         visible: false,
         interactiveChildren: true,
@@ -39,9 +34,9 @@ export const Scoreboard = (): Entity => {
 
             players.forEach((player) => {
               if (player.entity.components.team.data.team === 1) {
-                team1.addItem(makeInnerContainer(player.entity, width, w));
+                team1.addItem(playerRow(player.entity, width, w));
               } else {
-                team2.addItem(makeInnerContainer(player.entity, width, w));
+                team2.addItem(playerRow(player.entity, width, w));
               }
             });
           }
@@ -66,7 +61,7 @@ export const Scoreboard = (): Entity => {
   return scoreboard;
 }
 
-const makeInnerContainer = (entity: Entity<Team | Player>, width: number, world: World): Container => {
+const playerRow = (entity: Entity<Team | Player>, width: number, world: World): Container => {
   const { team, player } = entity.components;
 
   const box = (g: Graphics): Graphics => {

--- a/core/src/ecs/systems/ui/InputSystem.ts
+++ b/core/src/ecs/systems/ui/InputSystem.ts
@@ -86,6 +86,9 @@ export const InputSystem = ClientSystemBuilder({
       if (document.hasFocus()) {
         const keyName = event.key.toLowerCase();
 
+        // ignore noisy capslock events
+        if (keyName === "capslock" && !event.getModifierState("CapsLock")) return;
+
         // prevent defaults
         if (charactersPreventDefault.has(keyName)) event.preventDefault();
 
@@ -253,6 +256,7 @@ export const InputSystem = ClientSystemBuilder({
         })
 
         bufferedUp.clear();
+        bufferedDown.remove("capslock"); // capslock doesn't emit keyup event
       }
     }
   }

--- a/core/src/utils/MathUtils.ts
+++ b/core/src/utils/MathUtils.ts
@@ -3,6 +3,8 @@ import { Container } from "pixi.js";
 
 export type XY = { x: number, y: number };
 
+export const equalsXY = (a: XY, b: XY) => a.x === b.x && a.y === b.y;
+
 export const orthoToDirection = (o: number) => {
   if (o === 0) return "l";
   if (o === 1) return "ul";

--- a/core/src/utils/PixiUtils.ts
+++ b/core/src/utils/PixiUtils.ts
@@ -39,7 +39,7 @@ export const pixiText = ({ text, pos, style, anchor }: pixiTextProps): Text => {
     resolution: 2,
     style: {
       fill: style?.fill ?? 0xffffff,
-      fontSize: style?.fontSize ?? 14,
+      fontSize: style?.fontSize ?? 14
     }
   });
 }

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -38,7 +38,7 @@ export const Header = ({ world, netState, setNetState }: HeaderProps) => (
 
     <div style={{ position: 'absolute', right: 0, bottom: 0 }}>
       <span style={{ fontFamily: "sans-serif", fontSize: 14, marginRight: 5, verticalAlign: "-70%" }}>
-        v<b>0.6.16</b>
+        v<b>0.6.17</b>
       </span>
       <a style={{ margin: 0, color: "inherit", textDecoration: "none" }} target="_blank" href="https://discord.gg/VfFG9XqDpJ">
         <FaDiscord size={20} style={{ color: "white", verticalAlign: "-80%" }}></FaDiscord>


### PR DESCRIPTION
- pressing `capslock` toggles fullscreen view of the minimap
- brought in the work from #153 to reduce the number of tile colliders (edges still aren't "smooth", just more performant)