### PR TITLE
v0.8.10 UI improvements

### DIFF
--- a/core/src/ecs/entities/ui/FpsText.ts
+++ b/core/src/ecs/entities/ui/FpsText.ts
@@ -11,7 +11,7 @@ export const FpsText = ({ x, y }: FpsTextProps = {}) => Entity<Position | Render
   persists: true,
   components: {
     position: Position({
-      x: x ?? -200, y: y ?? 10, screenFixed: true
+      x: x ?? 5, y: y ?? 10, screenFixed: true
     }),
     renderable: Renderable({
       zIndex: 3,
@@ -33,7 +33,7 @@ export const LagText = ({ x, y }: FpsTextProps = {}) => Entity<Position | Render
   persists: true,
   components: {
     position: Position({
-      x: x ?? -250, y: y ?? 10, screenFixed: true
+      x: x ?? 5, y: y ?? 30, screenFixed: true
     }),
     renderable: Renderable({
       zIndex: 3,

--- a/core/src/ecs/systems/ui/InputSystem.ts
+++ b/core/src/ecs/systems/ui/InputSystem.ts
@@ -56,6 +56,7 @@ export const InputSystem = ClientSystemBuilder({
 
       mouseEvent = { x: event.offsetX, y: event.offsetY }
       mouse = { hold: false, ...renderer.camera.toWorldCoords(mouseEvent) }
+      mouseScreen = { x: event.offsetX, y: event.offsetY }
 
       if (CurrentJoystickPosition.active && !joystickOn) {
         joystickOn = true

--- a/core/src/graphics/Renderer.ts
+++ b/core/src/graphics/Renderer.ts
@@ -70,7 +70,7 @@ export const Renderer = (props: RendererProps): Renderer => {
     handleResize: () => {
       if (isMobile() || (document.fullscreenElement && renderer.app.renderer)) {
         console.log("resizing to fullscreen");
-        renderer.app.renderer.resize(window.innerWidth, window.innerHeight);
+        renderer.app.renderer.resize(window.innerWidth, window.outerHeight);
       } else {
         renderer.app.renderer.resize(window.innerWidth * 0.98, window.innerHeight * 0.90);
       }

--- a/core/src/runtime/IsometricGame.ts
+++ b/core/src/runtime/IsometricGame.ts
@@ -1,4 +1,4 @@
-import { PvPHUD, Chat, ConnectButton, Cursor, FullscreenButton, GameBuilder, Joystick, isMobile, ShopButton, MobilePvPHUD } from "@piggo-gg/core";
+import { Chat, Cursor, FullscreenButton, GameBuilder, isMobile, Joystick } from "@piggo-gg/core";
 
 export const IsometricGame = <T extends string>(gameBuilder: GameBuilder<T>): GameBuilder<T> => ({
   ...gameBuilder,
@@ -6,7 +6,7 @@ export const IsometricGame = <T extends string>(gameBuilder: GameBuilder<T>): Ga
     const game = gameBuilder.init(world);
 
     if (world.runtimeMode === "client") isMobile() ?
-      game.entities.push(Joystick(), ShopButton()) :
+      game.entities.push(Joystick()) :
       game.entities.push(FullscreenButton(), Cursor(), Chat());
 
     return game;

--- a/docs/index.css
+++ b/docs/index.css
@@ -46,6 +46,11 @@ canvas {
   height: 100vh;
   object-fit: fill;
   display: block;
+  user-select: none;
+  -webkit-touch-callout: none; /* Disable the callout on iOS */
+  -webkit-user-select: none;   /* Disable text selection on iOS */
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); /* Remove tap highlight */
+  touch-action: none; /* Disable default touch actions like zooming */
 }
 
 video {

--- a/games/sandbox/Sandbox.ts
+++ b/games/sandbox/Sandbox.ts
@@ -1,5 +1,5 @@
 import {
-  HomeButton, InventorySystem, IsometricGame,
+  InventorySystem, IsometricGame,
   Piggo, SkellySpawnSystem, Tree, isMobile, MobilePvEHUD, PvEHUD
 } from "@piggo-gg/core"
 
@@ -9,7 +9,6 @@ export const Sandbox = IsometricGame({
     id: "sandbox",
     systems: [SkellySpawnSystem, InventorySystem],
     entities: [
-      HomeButton(),
       isMobile() ? MobilePvEHUD() : PvEHUD(),
       Piggo(), Piggo(), Piggo(), Piggo(), Piggo(), Piggo(), Piggo(),
       Tree(), Tree(), Tree(), Tree(), Tree(), Tree(), Tree(), Tree(), Tree()

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -38,7 +38,7 @@ export const Header = ({ world, netState, setNetState }: HeaderProps) => (
 
     <div style={{ position: 'absolute', right: 0, bottom: 0 }}>
       <span style={{ fontFamily: "sans-serif", fontSize: 14, marginRight: 5, verticalAlign: "-70%" }}>
-        v<b>0.8.9</b>
+        v<b>0.8.10</b>
       </span>
       <a style={{ margin: 0, color: "inherit", textDecoration: "none" }} target="_blank" href="https://discord.gg/VfFG9XqDpJ">
         <FaDiscord size={20} style={{ color: "white", verticalAlign: "-80%" }}></FaDiscord>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -46,6 +46,11 @@ canvas {
   height: 100vh;
   object-fit: fill;
   display: block;
+  user-select: none;
+  -webkit-touch-callout: none; /* Disable the callout on iOS */
+  -webkit-user-select: none;   /* Disable text selection on iOS */
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); /* Remove tap highlight */
+  touch-action: none; /* Disable default touch actions like zooming */
 }
 
 video {


### PR DESCRIPTION
- fixing mobile `pointerdown` wasn't updating the tool position
- rm `shop` and `home` buttons
- #189 worked for mobile PWA (had to recreate the widget) but the screen size was too small (bottom missing) trying a fix `outerHeight`
- trying a fix for holding down on canvas in mobile was bringing up a zoom magnifier