### PR TITLE
v0.8.13 more mobile fixes

### DIFF
--- a/core/src/graphics/Renderer.ts
+++ b/core/src/graphics/Renderer.ts
@@ -66,6 +66,9 @@ export const Renderer = (props: RendererProps): Renderer => {
       canvas.addEventListener("wheel", (event) => {
         renderer.camera?.rescaleDelta(-event.deltaY / 1000);
       });
+
+      // resize once (for mobile PWA)
+      renderer.handleResize();
     },
     handleResize: () => {
       if (isMobile() || (document.fullscreenElement && renderer.app.renderer)) {

--- a/docs/index.css
+++ b/docs/index.css
@@ -48,7 +48,7 @@ canvas {
   top: 0;
   left: 0;
   width: 100vw;
-  height: 100vh;
+  height: calc(100vh + env(safe-area-inset-bottom));
   object-fit: fill;
   display: block;
   user-select: none;

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -38,7 +38,7 @@ export const Header = ({ world, netState, setNetState }: HeaderProps) => (
 
     <div style={{ position: 'absolute', right: 0, bottom: 0 }}>
       <span style={{ fontFamily: "sans-serif", fontSize: 14, marginRight: 5, verticalAlign: "-70%" }}>
-        v<b>0.8.12</b>
+        v<b>0.8.13</b>
       </span>
       <a style={{ margin: 0, color: "inherit", textDecoration: "none" }} target="_blank" href="https://discord.gg/VfFG9XqDpJ">
         <FaDiscord size={20} style={{ color: "white", verticalAlign: "-80%" }}></FaDiscord>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -48,7 +48,7 @@ canvas {
   top: 0;
   left: 0;
   width: 100vw;
-  height: 100vh;
+  height: calc(100vh + env(safe-area-inset-bottom));
   object-fit: fill;
   display: block;
   user-select: none;


### PR DESCRIPTION
- canvas resize to include safe-area-bottom
- call `renderer.handleResize()` on init 