### PR TITLE
v0.10.11 fix dropping items in multiplayer

### DIFF
--- a/core/src/ecs/actions/interactive/ItemActions.ts
+++ b/core/src/ecs/actions/interactive/ItemActions.ts
@@ -34,7 +34,6 @@ export const pickupItem = Action("pickupItem", ({ player, entity, world }) => {
   inventory.addItem(entity as ItemEntity, world)
 })
 
-// attach to item - not the player ?
 export const dropItem = Action("dropItem", ({ world, entity }) => {
   if (!entity) return
 

--- a/core/src/ecs/actions/interactive/ItemActions.ts
+++ b/core/src/ecs/actions/interactive/ItemActions.ts
@@ -34,17 +34,17 @@ export const pickupItem = Action("pickupItem", ({ player, entity, world }) => {
   inventory.addItem(entity as ItemEntity, world)
 })
 
-export const dropItem = Action("dropItem", ({ world }) => {
-  const character = world.client?.playerCharacter()
-  if (!character) return
+// attach to item - not the player ?
+export const dropItem = Action("dropItem", ({ world, entity }) => {
+  if (!entity) return
 
-  const { inventory } = character.components
+  const { inventory } = entity.components
   if (!inventory) return
 
   const activeItem = inventory.activeItem(world)
   if (!activeItem) return
 
-  const { item, position, collider, clickable } = activeItem.components
+  const { item, position, clickable, collider } = activeItem.components
 
   item.dropped = true
   position.data.follows = undefined

--- a/core/src/ecs/actions/movement/WASDInputMap.ts
+++ b/core/src/ecs/actions/movement/WASDInputMap.ts
@@ -1,6 +1,6 @@
 import { Entity, InputMap, InvokedAction, Position, World, XY, normalize } from "@piggo-gg/core"
 
-export const WASDInputMap: InputMap = {
+export const WASDInputMap: Partial<InputMap> = {
   press: {
     "a,d": () => null, "w,s": () => null,
     "w,a": ({ entity, world }) => move(entity, world, -1, -2),

--- a/core/src/ecs/components/Input.ts
+++ b/core/src/ecs/components/Input.ts
@@ -14,16 +14,21 @@ export type JoystickHandler = (_: { character: Character, world: World }) => nul
 
 // "" is always allowed to clear the input buffer
 export type InputMap = {
-  press?: Record<string, KeyHandler>
-  release?: Record<string, KeyHandler>
-  joystick?: JoystickHandler
+  press: Record<string, KeyHandler>
+  release: Record<string, KeyHandler>
+  joystick: JoystickHandler
 }
 
 export type Input = Component<"input"> & {
   inputMap: InputMap
 }
 
-export const Input = (inputMap: InputMap): Input => ({
+export const Input = (inputMap: Partial<InputMap> = {}): Input => ({
   type: "input",
-  inputMap
+  inputMap: {
+    press: {},
+    release: {},
+    joystick: () => null,
+    ...inputMap
+  }
 })

--- a/core/src/ecs/components/Item.ts
+++ b/core/src/ecs/components/Item.ts
@@ -1,6 +1,6 @@
 import {
-  Actions, Clickable, Component, Debug, Effects, Entity, Networked, Position,
-  ProtoEntity, Renderable, SystemBuilder, abs, hypot, min, pickupItem, round
+  Actions, Clickable, Component, Debug, Effects, Entity, Input, Networked, Position,
+  ProtoEntity, Renderable, SystemBuilder, abs, dropItem, hypot, min, pickupItem, round
 } from "@piggo-gg/core"
 
 export type Item = Component<"item"> & {

--- a/core/src/ecs/entities/characters/Skelly.ts
+++ b/core/src/ecs/entities/characters/Skelly.ts
@@ -30,7 +30,7 @@ export const Skelly = (player: Player, color?: number, pos?: XY) => {
         },
         joystick: DefaultJoystickHandler
       }),
-      actions: Actions({
+      actions: Actions<any>({
         move: Move,
         point: Point,
         setActiveItemIndex,

--- a/core/src/ecs/entities/items/Guns.ts
+++ b/core/src/ecs/entities/items/Guns.ts
@@ -15,7 +15,9 @@ export const GunItem = (name: string, gun: () => Gun): ItemBuilder => ({ id, cha
     gun: gun(),
     effects: Effects(),
     item: Item({ name }),
-    clickable: Clickable({ width: 0, height: 0, active: false }),
+    clickable: Clickable({
+      width: 20, height: 20, active: false, anchor: { x: 0.5, y: 0.5 }
+    }),
     renderable: Renderable({
       scaleMode: "nearest",
       zIndex: 3,

--- a/core/src/ecs/entities/items/Tools.ts
+++ b/core/src/ecs/entities/items/Tools.ts
@@ -1,6 +1,6 @@
 import {
   Actions, Clickable, Effects, ElementKinds, Item, ItemBuilder, ItemEntity,
-  Position, Renderable, ValidSounds, Whack, loadTexture, randomInt
+  Position, Renderable, ValidSounds, Whack, loadTexture
 } from "@piggo-gg/core"
 import { Sprite } from "pixi.js"
 

--- a/core/src/ecs/entities/objects/Apple.ts
+++ b/core/src/ecs/entities/objects/Apple.ts
@@ -1,8 +1,7 @@
 import {
   Actions, Clickable, Collider, Item, Effects, Element,
   Food, Health, ItemEntity, Networked, Position,
-  Renderable, XY, loadTexture, randomInt, NPC,
-  Input
+  Renderable, XY, loadTexture, randomInt, NPC
 } from "@piggo-gg/core"
 import { Sprite } from "pixi.js"
 

--- a/core/src/ecs/entities/objects/Apple.ts
+++ b/core/src/ecs/entities/objects/Apple.ts
@@ -1,7 +1,8 @@
 import {
   Actions, Clickable, Collider, Item, Effects, Element,
   Food, Health, ItemEntity, Networked, Position,
-  Renderable, XY, loadTexture, randomInt, NPC
+  Renderable, XY, loadTexture, randomInt, NPC,
+  Input
 } from "@piggo-gg/core"
 import { Sprite } from "pixi.js"
 

--- a/web/src/components/TitleBar.tsx
+++ b/web/src/components/TitleBar.tsx
@@ -37,7 +37,7 @@ export const TitleBar = ({ world, loginState, setLoginState }: TitleBarProps) =>
 
     <div style={{ position: 'absolute', right: 0, bottom: 0 }}>
       <span style={{ fontFamily: "sans-serif", fontSize: 14, marginRight: 5, verticalAlign: "-70%" }}>
-        v<b>0.10.10</b>
+        v<b>0.10.11</b>
       </span>
       <a style={{ margin: 0, color: "inherit", textDecoration: "none" }} target="_blank" href="https://discord.gg/VfFG9XqDpJ">
         <FaDiscord size={20} style={{ color: "white", verticalAlign: "-80%" }}></FaDiscord>


### PR DESCRIPTION
the `dropItem` action was looking for `world.client.playerCharacter()` which doesn't work in multiplayer

- fix `dropItem`
- guns can now be picked up