### PR TITLE
color-scheme: light

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -5,7 +5,7 @@ html {
   border-right-color: rgb(115, 107, 94);
   border-top-color: rgb(115, 107, 94);
   color: rgb(232, 230, 227);
-  color-scheme: dark !important;
+  color-scheme: light;
 
   -webkit-user-select: none; /* Safari */
   -ms-user-select: none; /* IE 10 and IE 11 */

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -5,7 +5,7 @@ html {
   border-right-color: rgb(115, 107, 94);
   border-top-color: rgb(115, 107, 94);
   color: rgb(232, 230, 227);
-  color-scheme: dark !important;
+  color-scheme: light;
 
   -webkit-user-select: none; /* Safari */
   -ms-user-select: none; /* IE 10 and IE 11 */


### PR DESCRIPTION
seeing an issue where in production, google uses an iframe and it has a white background. trying [this fix](https://stackoverflow.com/questions/75226935/white-background-issue-around-sign-in-with-google-button-and-one-tap-popup)

|dev|prod|
|--|--|
|<img width="196" alt="Screenshot 2025-03-24 at 1 24 54 PM" src="https://github.com/user-attachments/assets/4e98929a-b518-4c41-861f-f73374c01ffc" />|<img width="221" alt="Screenshot 2025-03-24 at 1 24 36 PM" src="https://github.com/user-attachments/assets/d8cf3b99-6983-46e3-acea-cf1c66c56369" />
