### PR TITLE
v0.17.1 refactor blocks

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -9,6 +9,7 @@
     "pixi-filters": "6.0.3",
     "pixi.js": "8.8.1",
     "react-hot-toast": "2.4.1",
+    "simplex-noise": "^4.0.3",
     "tone": "15.0.4"
   }
 }

--- a/core/src/ecs/components/Collider.ts
+++ b/core/src/ecs/components/Collider.ts
@@ -42,7 +42,7 @@ export const ColliderGroups = {
   "30":    "01100000000000001100000000000000",
   "31":    "11000000000000011000000000000000",
   "32":    "00000000000001110000000000000111"
-} as const;
+} as const
 
 export type Collider = Component<"collider"> & {
   body: RigidBody | undefined

--- a/core/src/ecs/components/Debug.ts
+++ b/core/src/ecs/components/Debug.ts
@@ -30,7 +30,7 @@ export const DebugSystem = ClientSystemBuilder({
 
       // text box
       const textBox = TextBox({
-        dynamic: ({ container, renderable }) => {
+        onTick:({ container, renderable }) => {
           const c = container as Text
           if (renderable && position) {
             const bounds = renderable.c.getLocalBounds()
@@ -43,7 +43,7 @@ export const DebugSystem = ClientSystemBuilder({
       })
 
       const lineToHeading = Renderable({
-        dynamic: ({ container }) => {
+        onTick:({ container }) => {
           const c = container as Graphics
           if (position.data.heading.x || position.data.heading.y) {
             c.clear().setStrokeStyle({ width: 1, color: 0x00ffff })
@@ -92,7 +92,7 @@ export const DebugSystem = ClientSystemBuilder({
     const drawAllColliders = () => {
 
       const r = Renderable({
-        dynamic: ({ container }) => {
+        onTick:({ container }) => {
           const g = container as Graphics
           g.clear().setStrokeStyle({ width: 1, color: 0xffff00 })
           const { vertices } = physics.debugRender()

--- a/core/src/ecs/components/Debug.ts
+++ b/core/src/ecs/components/Debug.ts
@@ -30,7 +30,7 @@ export const DebugSystem = ClientSystemBuilder({
 
       // text box
       const textBox = TextBox({
-        onTick:({ container, renderable }) => {
+        onTick: ({ container, renderable }) => {
           const c = container as Text
           if (renderable && position) {
             const bounds = renderable.c.getLocalBounds()
@@ -43,7 +43,7 @@ export const DebugSystem = ClientSystemBuilder({
       })
 
       const lineToHeading = Renderable({
-        onTick:({ container }) => {
+        onTick: ({ container }) => {
           const c = container as Graphics
           if (position.data.heading.x || position.data.heading.y) {
             c.clear().setStrokeStyle({ width: 1, color: 0x00ffff })
@@ -92,7 +92,7 @@ export const DebugSystem = ClientSystemBuilder({
     const drawAllColliders = () => {
 
       const r = Renderable({
-        onTick:({ container }) => {
+        onTick: ({ container }) => {
           const g = container as Graphics
           g.clear().setStrokeStyle({ width: 1, color: 0xffff00 })
           const { vertices } = physics.debugRender()

--- a/core/src/ecs/components/Position.ts
+++ b/core/src/ecs/components/Position.ts
@@ -28,7 +28,7 @@ export type Position = Component<"position", {
   setPosition: (_: { x?: number, y?: number, z?: number }) => Position
   setRotation: (_: number) => Position
   setVelocity: (_: { x?: number, y?: number, z?: number }) => Position
-  impulse: (_: XY) => Position
+  impulse: (_: XYZ) => Position
   interpolate: (_: number, __: World) => XYZ
   setSpeed: (_: number) => void
   setHeading: (_: XY) => Position
@@ -101,10 +101,11 @@ export const Position = (props: PositionProps = {}): Position => {
 
       return position.updateOrientation()
     },
-    impulse: ({ x, y }: XY) => {
+    impulse: ({ x, y, z }: XYZ) => {
       return position.setVelocity({
         x: position.data.velocity.x + x,
-        y: position.data.velocity.y + y
+        y: position.data.velocity.y + y,
+        z: position.data.velocity.z + z
       })
     },
     interpolate: (delta: number, world: World) => {

--- a/core/src/ecs/components/Renderable.ts
+++ b/core/src/ecs/components/Renderable.ts
@@ -36,7 +36,9 @@ export type Renderable = Component<"renderable", {
   setContainer: ((r: Renderer) => Promise<Container>) | undefined
   setChildren: ((r: Renderer) => Promise<Renderable[]>) | undefined
   setup: ((renderable: Renderable, renderer: Renderer, w: World) => Promise<void>) | undefined
-  dynamic: Dynamic | undefined
+
+  onRender: Dynamic | undefined
+  onTick: Dynamic | undefined
 
   prepareAnimations: (color?: number, alpha?: number) => void
   setScale: (xy: XY) => void
@@ -69,7 +71,8 @@ export type RenderableProps = {
   skin?: Skins
   visible?: boolean
   zIndex?: number
-  dynamic?: Dynamic
+  onRender?: Dynamic
+  onTick?: Dynamic
   setChildren?: (r: Renderer) => Promise<Renderable[]>
   setContainer?: (r: Renderer) => Promise<Container>
   setup?: (renderable: Renderable, renderer: Renderer, w: World) => Promise<void> // todo single arg
@@ -95,12 +98,15 @@ export const Renderable = (props: RenderableProps): Renderable => {
     children: undefined,
     cullable: props.cullable ?? false,
     currentSkin: undefined,
-    dynamic: props.dynamic,
     filters: {},
+    initialized: false,
     interactiveChildren: props.interactiveChildren ?? false,
     interpolate: props.interpolate ?? false,
-    initialized: false,
+    onRender: props.onRender,
+    onTick: props.onTick,
     position: props.position ?? { x: 0, y: 0 },
+    rendered: false,
+    renderer: undefined as unknown as Renderer,
     rotates: props.rotates ?? false,
     scale: props.scale ?? 1,
     scaleMode: props.scaleMode ?? "linear",
@@ -109,8 +115,6 @@ export const Renderable = (props: RenderableProps): Renderable => {
     setup: props.setup ?? undefined,
     visible: props.visible ?? true,
     zIndex: props.zIndex ?? 0,
-    rendered: false,
-    renderer: undefined as unknown as Renderer,
     prepareAnimations: (color: number = 0xffffff, alpha: number = 1) => {
       values(renderable.animations).forEach((animation: AnimatedSprite) => {
         animation.animationSpeed = 0.1

--- a/core/src/ecs/components/Renderable.ts
+++ b/core/src/ecs/components/Renderable.ts
@@ -225,7 +225,7 @@ export const Renderable = (props: RenderableProps): Renderable => {
       renderable.visible = false
 
       // remove from the world
-      // renderable.c.destroy() // TODO disabled because it breaks debug mode
+      renderable.c.destroy() // TODO disabled because it breaks debug mode
     },
     _init: async (renderer: Renderer | undefined, world: World) => {
       if (!renderer) return

--- a/core/src/ecs/components/Renderable.ts
+++ b/core/src/ecs/components/Renderable.ts
@@ -229,7 +229,7 @@ export const Renderable = (props: RenderableProps): Renderable => {
       renderable.visible = false
 
       // remove from the world
-      renderable.c.destroy() // TODO disabled because it breaks debug mode
+      // renderable.c.destroy() // TODO disabled because it breaks debug mode
     },
     _init: async (renderer: Renderer | undefined, world: World) => {
       if (!renderer) return

--- a/core/src/ecs/components/Shadow.ts
+++ b/core/src/ecs/components/Shadow.ts
@@ -70,28 +70,28 @@ const ShadowEntity = (target: Target, size: number, yOffset: number) => {
       renderable: Renderable({
         zIndex: target.components.renderable.zIndex,
         interpolate: true,
-        dynamic: ({ entity, world }) => {
+        onTick:({ entity, world }) => {
           const { position, renderable } = entity.components
           if (!position || !renderable) return
 
           const { data, lastCollided } = target.components.position
 
-          const highest = highestBlock(data)
+          // const highest = highestBlock(data)
 
-          position.setPosition({ x: data.x, y: data.y - (0.1 * world.flipped()) + yOffset, z: highest.z })
+          // position.setPosition({ x: data.x, y: data.y - (0.1 * world.flipped()) + yOffset, z: highest.z })
           position.setVelocity({ ...data.velocity, z: 0 })
           position.lastCollided = lastCollided
 
-          renderable.c.alpha = 0.25 - (data.z - highest.z) / 1000
+          // renderable.c.alpha = 0.25 - (data.z - highest.z) / 1000
 
-          mask.position.x = highest.x - position.data.x
-          mask.position.y = 9 + (highest.y - position.data.y)
+          // mask.position.x = highest.x - position.data.x
+          // mask.position.y = 9 + (highest.y - position.data.y)
 
-          if (highest.z > 21) {
-            renderable.c.setMask({ mask })
-          } else {
-            renderable.c.mask = null
-          }
+          // if (highest.z > 21) {
+          //   renderable.c.setMask({ mask })
+          // } else {
+          //   renderable.c.mask = null
+          // }
         },
         setup: async (renderable) => {
           renderable.c = pixiGraphics().ellipse(0, 1, size * 2, size).fill({ color: 0x000000, alpha: 1 })

--- a/core/src/ecs/components/Shadow.ts
+++ b/core/src/ecs/components/Shadow.ts
@@ -76,22 +76,22 @@ const ShadowEntity = (target: Target, size: number, yOffset: number) => {
 
           const { data, lastCollided } = target.components.position
 
-          // const highest = highestBlock(data)
+          const highest = highestBlock(data)
 
-          // position.setPosition({ x: data.x, y: data.y - (0.1 * world.flipped()) + yOffset, z: highest.z })
+          position.setPosition({ x: data.x, y: data.y - (0.1 * world.flipped()) + yOffset, z: highest.z })
           position.setVelocity({ ...data.velocity, z: 0 })
           position.lastCollided = lastCollided
 
-          // renderable.c.alpha = 0.25 - (data.z - highest.z) / 1000
+          renderable.c.alpha = 0.25 - (data.z - highest.z) / 1000
 
-          // mask.position.x = highest.x - position.data.x
-          // mask.position.y = 9 + (highest.y - position.data.y)
+          mask.position.x = highest.x - position.data.x
+          mask.position.y = 9 + (highest.y - position.data.y)
 
-          // if (highest.z > 21) {
-          //   renderable.c.setMask({ mask })
-          // } else {
-          //   renderable.c.mask = null
-          // }
+          if (highest.z > 21) {
+            renderable.c.setMask({ mask })
+          } else {
+            renderable.c.mask = null
+          }
         },
         setup: async (renderable) => {
           renderable.c = pixiGraphics().ellipse(0, 1, size * 2, size).fill({ color: 0x000000, alpha: 1 })

--- a/core/src/ecs/components/Shadow.ts
+++ b/core/src/ecs/components/Shadow.ts
@@ -70,7 +70,7 @@ const ShadowEntity = (target: Target, size: number, yOffset: number) => {
       renderable: Renderable({
         zIndex: target.components.renderable.zIndex,
         interpolate: true,
-        onTick:({ entity, world }) => {
+        onTick: ({ entity, world }) => {
           const { position, renderable } = entity.components
           if (!position || !renderable) return
 

--- a/core/src/ecs/components/Shadow.ts
+++ b/core/src/ecs/components/Shadow.ts
@@ -82,7 +82,7 @@ const ShadowEntity = (target: Target, size: number, yOffset: number) => {
           position.setVelocity({ ...data.velocity, z: 0 })
           position.lastCollided = lastCollided
 
-          renderable.c.alpha = 0.25 - (data.z - highest.z) / 500
+          renderable.c.alpha = 0.25 - (data.z - highest.z) / 1000
 
           mask.position.x = highest.x - position.data.x
           mask.position.y = 9 + (highest.y - position.data.y)

--- a/core/src/ecs/components/Shadow.ts
+++ b/core/src/ecs/components/Shadow.ts
@@ -76,7 +76,7 @@ const ShadowEntity = (target: Target, size: number, yOffset: number) => {
 
           const { data, lastCollided } = target.components.position
 
-          const highest = highestBlock(data, world)
+          const highest = highestBlock(data)
 
           position.setPosition({ x: data.x, y: data.y - (0.1 * world.flipped()) + yOffset, z: highest.z })
           position.setVelocity({ ...data.velocity, z: 0 })

--- a/core/src/ecs/entities/buttons/SwitchTeamButton.ts
+++ b/core/src/ecs/entities/buttons/SwitchTeamButton.ts
@@ -8,7 +8,7 @@ export const switchTeamButton = () => Entity({
       zIndex: 1,
       interactiveChildren: true,
       visible: false,
-      onTick:({ renderable, world }) => {
+      onTick: ({ renderable, world }) => {
         renderable.visible = world.client?.connected ?? false
       },
       setup: async (renderable, renderer, world) => {

--- a/core/src/ecs/entities/buttons/SwitchTeamButton.ts
+++ b/core/src/ecs/entities/buttons/SwitchTeamButton.ts
@@ -8,7 +8,7 @@ export const switchTeamButton = () => Entity({
       zIndex: 1,
       interactiveChildren: true,
       visible: false,
-      dynamic: ({ renderable, world }) => {
+      onTick:({ renderable, world }) => {
         renderable.visible = world.client?.connected ?? false
       },
       setup: async (renderable, renderer, world) => {

--- a/core/src/ecs/entities/characters/Chicko.ts
+++ b/core/src/ecs/entities/characters/Chicko.ts
@@ -32,7 +32,7 @@ export const Chicko = ({ id, positionProps = { x: randomInt(500), y: randomInt(5
         color: 0xffffff,
         scaleMode: "nearest",
         anchor: { x: 0.5, y: 0.7 },
-        dynamic: ({ renderable }) => {
+        onTick:({ renderable }) => {
           const { orientationRads } = chicko.components.position
 
           const x = (orientationRads > 2 && orientationRads < 6) ? 1 : -1

--- a/core/src/ecs/entities/characters/Chicko.ts
+++ b/core/src/ecs/entities/characters/Chicko.ts
@@ -32,7 +32,7 @@ export const Chicko = ({ id, positionProps = { x: randomInt(500), y: randomInt(5
         color: 0xffffff,
         scaleMode: "nearest",
         anchor: { x: 0.5, y: 0.7 },
-        onTick:({ renderable }) => {
+        onTick: ({ renderable }) => {
           const { orientationRads } = chicko.components.position
 
           const x = (orientationRads > 2 && orientationRads < 6) ? 1 : -1

--- a/core/src/ecs/entities/characters/Piggo.ts
+++ b/core/src/ecs/entities/characters/Piggo.ts
@@ -33,7 +33,7 @@ export const Piggo = ({ id, positionProps = { x: randomInt(400, 200), y: randomI
         color: 0xffffff,
         scaleMode: "nearest",
         anchor: { x: 0.5, y: 0.7 },
-        dynamic: ({ renderable }) => {
+        onTick:({ renderable }) => {
           const { orientationRads } = piggo.components.position
 
           const x = (orientationRads > 2 && orientationRads < 6) ? 1 : -1

--- a/core/src/ecs/entities/characters/Piggo.ts
+++ b/core/src/ecs/entities/characters/Piggo.ts
@@ -33,7 +33,7 @@ export const Piggo = ({ id, positionProps = { x: randomInt(400, 200), y: randomI
         color: 0xffffff,
         scaleMode: "nearest",
         anchor: { x: 0.5, y: 0.7 },
-        onTick:({ renderable }) => {
+        onTick: ({ renderable }) => {
           const { orientationRads } = piggo.components.position
 
           const x = (orientationRads > 2 && orientationRads < 6) ? 1 : -1

--- a/core/src/ecs/entities/characters/Skelly.ts
+++ b/core/src/ecs/entities/characters/Skelly.ts
@@ -69,7 +69,7 @@ export const Skelly = (player: Player, pos?: XY) => Character({
       scaleMode: "nearest",
       setup: DudeSkin("white"),
       animationSelect: VolleyCharacterAnimations,
-      dynamic: VolleyCharacterDynamic
+      onTick:VolleyCharacterDynamic
     })
   }
 })

--- a/core/src/ecs/entities/characters/Skelly.ts
+++ b/core/src/ecs/entities/characters/Skelly.ts
@@ -48,7 +48,7 @@ export const Skelly = (player: Player, pos?: XY) => Character({
       setActiveItemIndex,
       dropItem,
       jetpack: Action("jetpack", ({ entity }) => {
-        entity?.components?.position?.setVelocity({ z: 3 })
+        entity?.components?.position?.setVelocity({ z: 3 }) // todo use impulse
       }),
       jump: Action("jump", ({ entity }) => {
         if (!entity?.components?.position?.data.standing) return

--- a/core/src/ecs/entities/characters/Skelly.ts
+++ b/core/src/ecs/entities/characters/Skelly.ts
@@ -69,7 +69,7 @@ export const Skelly = (player: Player, pos?: XY) => Character({
       scaleMode: "nearest",
       setup: DudeSkin("white"),
       animationSelect: VolleyCharacterAnimations,
-      onTick:VolleyCharacterDynamic
+      onTick: VolleyCharacterDynamic
     })
   }
 })

--- a/core/src/ecs/entities/characters/Skelly.ts
+++ b/core/src/ecs/entities/characters/Skelly.ts
@@ -28,7 +28,7 @@ export const Skelly = (player: Player, pos?: XY) => Character({
       press: {
         ...WASDInputMap.press,
         " ": () => ({ actionId: "jump" }),
-        "shift": () => ({ actionId: "jetpack" }),
+        "r": () => ({ actionId: "jetpack" }),
         "g": () => ({ actionId: "dropItem" }),
         "1": () => ({ actionId: "setActiveItemIndex", params: { index: 0 } }),
         "2": () => ({ actionId: "setActiveItemIndex", params: { index: 1 } }),

--- a/core/src/ecs/entities/characters/Skelly.ts
+++ b/core/src/ecs/entities/characters/Skelly.ts
@@ -48,7 +48,7 @@ export const Skelly = (player: Player, pos?: XY) => Character({
       setActiveItemIndex,
       dropItem,
       jetpack: Action("jetpack", ({ entity }) => {
-        entity?.components?.position?.setVelocity({ z: 5 })
+        entity?.components?.position?.setVelocity({ z: 3 })
       }),
       jump: Action("jump", ({ entity }) => {
         if (!entity?.components?.position?.data.standing) return

--- a/core/src/ecs/entities/characters/Skelly.ts
+++ b/core/src/ecs/entities/characters/Skelly.ts
@@ -10,7 +10,7 @@ export const Skelly = (player: Player, pos?: XY) => Character({
   components: {
     debug: Debug(),
     position: Position({
-      x: pos?.x ?? 0, y: pos?.y ?? 0, z: 128,
+      x: pos?.x ?? 0, y: pos?.y ?? 200, z: 128,
       velocityResets: 1,
       speed: 125,
       gravity: 0.3

--- a/core/src/ecs/entities/characters/Zomi.ts
+++ b/core/src/ecs/entities/characters/Zomi.ts
@@ -35,7 +35,7 @@ export const Zomi = ({ id, color, positionProps = { x: randomInt(200, 100), y: r
         color: color ?? 0x00ff00,
         scaleMode: "nearest",
         anchor: { x: 0.5, y: 0.7 },
-        dynamic: ({ renderable }) => {
+        onTick:({ renderable }) => {
           const { hp, maxHp } = zomi.components.health.data
 
           const ratio = round(hp / maxHp * 4)

--- a/core/src/ecs/entities/characters/Zomi.ts
+++ b/core/src/ecs/entities/characters/Zomi.ts
@@ -35,7 +35,7 @@ export const Zomi = ({ id, color, positionProps = { x: randomInt(200, 100), y: r
         color: color ?? 0x00ff00,
         scaleMode: "nearest",
         anchor: { x: 0.5, y: 0.7 },
-        onTick:({ renderable }) => {
+        onTick: ({ renderable }) => {
           const { hp, maxHp } = zomi.components.health.data
 
           const ratio = round(hp / maxHp * 4)

--- a/core/src/ecs/entities/items/Block.ts
+++ b/core/src/ecs/entities/items/Block.ts
@@ -243,12 +243,6 @@ export const BlockItem = (type: BlockType): ItemBuilder => ({ character, id }) =
       mb1: ({ params, world }) => {
         const { hold, mouse } = params as ItemActionParams
         if (hold) return
-
-        // const block = Block(snapXYZ(world.flip(mouse), world), type)
-        // const block = Block(snapXYZ(world.flip(mouse), world), type)
-        // const block = BlockMesh(snapXYZ(world.flip(mouse), world))
-
-        // world.addEntity(block)
         // addToXBlocksBuffer(block)
 
         blocks.add({ ...snapXYZ(world.flip(mouse)), type })

--- a/core/src/ecs/entities/items/Block.ts
+++ b/core/src/ecs/entities/items/Block.ts
@@ -11,7 +11,7 @@ const height = width / 3 * 2
 type BlockType = "grass" | "moss" | "moonrock" | "asteroid" | "saphire" | "obsidian" | "ruby"
 
 const BlockColors: Record<BlockType, [number, number, number]> = {
-  grass: [0x08dd00, 0x6E260E, 0x7B3F00],
+  grass: [0x08d000, 0x6E260E, 0x7B3F00],
   moss: [0x08bb00, 0x6E260E, 0x7B3F00],
   moonrock: [0xcbdaf2, 0x98b0d9, 0xdddddd],
   asteroid: [0x8b8b8b, 0x6E6E6E, 0xECF0F1],

--- a/core/src/ecs/entities/items/Block.ts
+++ b/core/src/ecs/entities/items/Block.ts
@@ -61,7 +61,7 @@ const blockGraphics = (type: BlockType) => {
   return graphics[type]
 }
 
-export const Block = (pos: XYZ, type: BlockType) => Entity<Position>({
+const Block = (pos: XYZ, type: BlockType) => Entity<Position>({
   id: `block-${pos.x}-${pos.y}-${pos.z}`,
   components: {
     position: Position({ ...pos }),
@@ -163,12 +163,12 @@ export const highestBlock = (pos: XY, world: World): XYZ => {
   let level = 0
 
   // todo this is slow, should be a spatial hash ?
-  for (const block of blocks) {
-    const { x, y, z } = block.components.position!.data
-    if (x === snapped.x && y === snapped.y) {
-      level = Math.max(level, z + 21)
-    }
-  }
+  // for (const block of blocks) {
+  //   const { x, y, z } = block.components.position!.data
+  //   if (x === snapped.x && y === snapped.y) {
+  //     level = Math.max(level, z + 21)
+  //   }
+  // }
 
   return { x: snapped.x, y: snapped.y, z: level }
 }
@@ -507,7 +507,7 @@ export const BlockMesh = () => Entity({
   components: {
     position: Position(),
     renderable: Renderable({
-      zIndex: 10,
+      zIndex: 0,
       anchor: { x: 0.5, y: 0.5 },
       interpolate: true,
       setup: async (r) => {

--- a/core/src/ecs/entities/items/Block.ts
+++ b/core/src/ecs/entities/items/Block.ts
@@ -4,7 +4,7 @@ import {
   Item, ItemActionParams, ItemBuilder, ItemEntity, keys, mouse,
   pixiGraphics, Position, Renderable, round, values, World, XY, XYZ
 } from "@piggo-gg/core"
-import { Geometry, Graphics, Mesh, Shader } from "pixi.js"
+import { Geometry, Graphics, Mesh, Shader, Buffer, BufferUsage } from "pixi.js"
 
 const width = 18
 const height = width / 3 * 2
@@ -356,6 +356,12 @@ const geometry = new Geometry({
     9, 11, 10,
   ],
   attributes: {
+    // aInstanceOffset: {
+    //   instance: true,
+    //   buffer: new Buffer({
+
+    //   })
+    // },
     aUV: [
       // top
       0.0, 0.82, 0.0,

--- a/core/src/ecs/entities/items/Block.ts
+++ b/core/src/ecs/entities/items/Block.ts
@@ -515,8 +515,8 @@ export const BlockMesh = () => {
           const { position } = world.client!.playerCharacter()?.components ?? {}
           if (!position) return
 
-          const { z: playerZ } = position.data
-          const { y: playerY } = world.flip(position.data)
+          const playerZ = position.data.z - 20
+          const playerY = world.flip(position.data).y
 
           blocks.sort(world)
           const { data } = blocks
@@ -592,8 +592,8 @@ export const BlockMeshOcclusion = () => {
           const { position } = world.client!.playerCharacter()?.components ?? {}
           if (!position) return
 
-          const { z: playerZ } = position.data
-          const { y: playerY } = world.flip(position.data)
+          const playerZ = position.data.z - 20
+          const playerY = world.flip(position.data).y
 
           blocks.sort(world)
           const { data } = blocks

--- a/core/src/ecs/entities/items/Block.ts
+++ b/core/src/ecs/entities/items/Block.ts
@@ -8,11 +8,12 @@ import { Geometry, Graphics, Mesh, Shader, Buffer, BufferUsage } from "pixi.js"
 const width = 18
 const height = width / 3 * 2
 
-export type BlockType = "grass" | "moss" | "moonrock" | "asteroid" | "saphire" | "obsidian" | "ruby"
+export type BlockType = "stone" | "grass" | "moss" | "moonrock" | "asteroid" | "saphire" | "obsidian" | "ruby"
 
 export type Voxel = XYZ & { type: BlockType }
 
 const BlockColors: Record<BlockType, [number, number, number]> = {
+  stone: [0x7b7b7b, 0x5E5E3E, 0x9b9b9b],
   grass: [0x08d000, 0x6E260E, 0x7B3F00],
   moss: [0x08bb00, 0x6E260E, 0x7B3F00],
   moonrock: [0xcbdaf2, 0x98b0d9, 0xdddddd],
@@ -23,6 +24,7 @@ const BlockColors: Record<BlockType, [number, number, number]> = {
 }
 
 const graphics: Record<BlockType, Graphics | undefined> = {
+  stone: undefined,
   grass: undefined,
   moss: undefined,
   moonrock: undefined,

--- a/core/src/ecs/entities/items/Block.ts
+++ b/core/src/ecs/entities/items/Block.ts
@@ -1,5 +1,6 @@
 import {
   Actions, Clickable, Collider, Debug, Effects, Element, Entity,
+  floor,
   Item, ItemActionParams, ItemBuilder, ItemEntity, keys, mouse,
   pixiGraphics, Position, Renderable, round, values, World, XY, XYZ
 } from "@piggo-gg/core"
@@ -8,7 +9,7 @@ import { Graphics } from "pixi.js"
 const width = 18
 const height = width / 3 * 2
 
-type BlockType = "grass" | "moss" | "moonrock" | "asteroid" | "saphire" | "obsidian" | "ruby"
+export type BlockType = "grass" | "moss" | "moonrock" | "asteroid" | "saphire" | "obsidian" | "ruby"
 
 const BlockColors: Record<BlockType, [number, number, number]> = {
   grass: [0x08d000, 0x6E260E, 0x7B3F00],
@@ -103,9 +104,9 @@ export const Block = (pos: XYZ, type: BlockType) => Entity<Position>({
         clone.position.y = -height
         r.c.addChild(clone)
 
-        if (pos.z > 0) {
-          // r.setOutline({ color: 0x000000, thickness: 0.2 })
-        }
+        // if (pos.z > 0) {
+          r.setOutline({ color: 0x000000, thickness: 0.2 })
+        // }
       }
     })
   }
@@ -116,6 +117,22 @@ export const intToBlock = (i: number, j: number): XY => ({
   x: (i - j) * width,
   y: (i + j) * width / 2
 })
+
+const xyBlock = (pos: XY): XY => {
+  const half = width / 2
+  const gridX = (pos.x / width + pos.y / half) / 2
+  const gridY = (pos.y / half - pos.x / width) / 2
+  const tileX = round(gridX)
+  const tileY = round(gridY)
+  return { x: tileX, y: tileY }
+}
+
+export const snapXYToChunk = (pos: XY): XY => {
+  const snapped = xyBlock(pos)
+  const x = floor(snapped.x / 4)
+  const y = floor(snapped.y / 4)
+  return { x, y }
+}
 
 export const snapXY = (pos: XY): XY => {
   const half = width / 2

--- a/core/src/ecs/entities/items/Block.ts
+++ b/core/src/ecs/entities/items/Block.ts
@@ -8,10 +8,11 @@ import { Graphics } from "pixi.js"
 const width = 18
 const height = width / 3 * 2
 
-type BlockType = "grass" | "moonrock" | "asteroid" | "saphire" | "obsidian" | "ruby"
+type BlockType = "grass" | "moss" | "moonrock" | "asteroid" | "saphire" | "obsidian" | "ruby"
 
 const BlockColors: Record<BlockType, [number, number, number]> = {
   grass: [0x08dd00, 0x6E260E, 0x7B3F00],
+  moss: [0x08bb00, 0x6E260E, 0x7B3F00],
   moonrock: [0xcbdaf2, 0x98b0d9, 0xdddddd],
   asteroid: [0x8b8b8b, 0x6E6E6E, 0xECF0F1],
   saphire: [0x00afff, 0x007fff, 0x00cfff],
@@ -21,6 +22,7 @@ const BlockColors: Record<BlockType, [number, number, number]> = {
 
 const graphics: Record<BlockType, Graphics | undefined> = {
   grass: undefined,
+  moss: undefined,
   moonrock: undefined,
   asteroid: undefined,
   saphire: undefined,
@@ -82,6 +84,20 @@ export const Block = (pos: XYZ, type: BlockType) => Entity<Position>({
       scaleMode: "nearest",
       zIndex: 3,
       cullable: true,
+      dynamic: ({ entity, world }) => {
+        // if (world.tick % 200 !== 0) return
+        if (
+          world.entity(`block-${pos.x}-${pos.y}-${pos.z + 21}`) &&
+          world.entity(`block-${pos.x - width}-${pos.y + width / 2}-${pos.z}`) &&
+          world.entity(`block-${pos.x + width}-${pos.y + width / 2}-${pos.z}`)
+        ) {
+          entity.components.renderable.visible = false
+          // console.log("block hidden")
+        } else {
+          // entity.components.renderable.visible = true
+          // console.log("block visible")
+        }
+      },
       setup: async (r) => {
         const clone = blockGraphics(type).clone()
         clone.position.y = -height
@@ -101,6 +117,7 @@ export const intToBlock = (i: number, j: number): XY => {
   const x = (i - j) * width
   const y = (i + j) * width / 2
 
+  console.log("intToBlock", x, y)
   return { x, y }
 }
 

--- a/core/src/ecs/entities/items/Block.ts
+++ b/core/src/ecs/entities/items/Block.ts
@@ -1,6 +1,6 @@
 import {
   Actions, Clickable, Collider, Debug, Effects, Element, Entity,
-  Health, Item, ItemActionParams, ItemBuilder, ItemEntity, keys, mouse,
+  Item, ItemActionParams, ItemBuilder, ItemEntity, keys, mouse,
   pixiGraphics, Position, Renderable, round, values, World, XY, XYZ
 } from "@piggo-gg/core"
 import { Graphics } from "pixi.js"
@@ -111,15 +111,11 @@ export const Block = (pos: XYZ, type: BlockType) => Entity<Position>({
   }
 })
 
-
 // takes ij integer coordinates -> XY of that block from origin
-export const intToBlock = (i: number, j: number): XY => {
-  const x = (i - j) * width
-  const y = (i + j) * width / 2
-
-  console.log("intToBlock", x, y)
-  return { x, y }
-}
+export const intToBlock = (i: number, j: number): XY => ({
+  x: (i - j) * width,
+  y: (i + j) * width / 2
+})
 
 export const snapXY = (pos: XY): XY => {
   const half = width / 2

--- a/core/src/ecs/entities/items/Block.ts
+++ b/core/src/ecs/entities/items/Block.ts
@@ -1,5 +1,5 @@
 import {
-  Actions, Clickable, Effects, Entity, floor, Item, ItemActionParams,
+  Actions, Clickable, Collider, Effects, Entity, floor, Item, ItemActionParams,
   ItemBuilder, ItemEntity, mouse, pixiGraphics, Position,
   Renderable, round, World, XY, XYZ
 } from "@piggo-gg/core"
@@ -61,6 +61,27 @@ const blockGraphics = (type: BlockType) => {
 
   return graphics[type]
 }
+
+export const BlockCollider = (n: number) => Entity<Position | Collider>({
+  id: `terrain-collider-${n}`,
+  components: {
+    position: Position(),
+    collider: Collider({
+      cullable: true,
+      group: "1",
+      hittable: true,
+      isStatic: true,
+      shape: "line",
+      points: [
+        0, width / 2,
+        -width, 0,
+        0, 3 - height,
+        width, 0,
+        0, width / 2
+      ]
+    })
+  }
+})
 
 // takes ij integer coordinates -> XY of that block from origin
 export const intToBlock = (i: number, j: number): XY => ({
@@ -588,7 +609,6 @@ export const BlockMeshOcclusion = () => {
             shader.resources.uniforms.uniforms.uResolution = resolution
           }
 
-          // const playerPos = world.client!.playerCharacter()?.components.position.data
           const { position } = world.client!.playerCharacter()?.components ?? {}
           if (!position) return
 

--- a/core/src/ecs/entities/items/Block.ts
+++ b/core/src/ecs/entities/items/Block.ts
@@ -343,50 +343,9 @@ export const BlockItem = (type: BlockType): ItemBuilder => ({ character, id }) =
 
 // -----------------------------
 
-const blockGeometry = (): Geometry => {
-  const geometry = new Geometry()
-
-  const uvs = new Float32Array([
-    // top
-    0.0, 0.82, 0.0,
-    0.0, 0.82, 0.0,
-    0.0, 0.82, 0.0,
-    0.0, 0.82, 0.0,
-
-    // left (placeholder UVs)
-    0.5, 0.2, 0.0,
-    0.5, 0.2, 0.0,
-    0.5, 0.2, 0.0,
-    0.5, 0.2, 0.0,
-
-    // right (placeholder UVs)
-    0.6, 0.3, 0.0,
-    0.6, 0.3, 0.0,
-    0.6, 0.3, 0.0,
-    0.6, 0.3, 0.0,
-  ])
-
-  const positions = new Float32Array([
-    // top
-    0, 0,
-    -width, width / 2,
-    0, width,
-    width, width / 2,
-
-    // bottom-left
-    0, 0,
-    -width, width / 2,
-    -width, -height,
-    0, -height - width / 2,
-
-    // bottom-right
-    0, 0,
-    width, width / 2,
-    width, -height,
-    0, -height - width / 2,
-  ])
-
-  const indices = [
+const geometry = new Geometry({
+  instanceCount: 5,
+  indexBuffer: [
     0, 1, 2,
     0, 2, 3,
 
@@ -395,19 +354,53 @@ const blockGeometry = (): Geometry => {
 
     8, 9, 11,
     9, 11, 10,
-  ]
+  ],
+  attributes: {
+    aUV: [
+      // top
+      0.0, 0.82, 0.0,
+      0.0, 0.82, 0.0,
+      0.0, 0.82, 0.0,
+      0.0, 0.82, 0.0,
 
-  geometry.addAttribute('aVertexPosition', positions)
-  geometry.addAttribute('aUV', uvs)
-  geometry.addIndex(indices)
+      // left (placeholder UVs)
+      0.5, 0.2, 0.0,
+      0.5, 0.2, 0.0,
+      0.5, 0.2, 0.0,
+      0.5, 0.2, 0.0,
 
-  return geometry
-}
+      // right (placeholder UVs)
+      0.6, 0.3, 0.0,
+      0.6, 0.3, 0.0,
+      0.6, 0.3, 0.0,
+      0.6, 0.3, 0.0,
+    ],
+    aPosition: [
+      // top
+      0, 0,
+      -width, width / 2,
+      0, width,
+      width, width / 2,
+
+      // bottom-left
+      0, 0,
+      -width, width / 2,
+      -width, -height,
+      0, -height - width / 2,
+
+      // bottom-right
+      0, 0,
+      width, width / 2,
+      width, -height,
+      0, -height - width / 2,
+    ]
+  }
+})
 
 const vertexSrc = `
   precision mediump float;
 
-  attribute vec2 aVertexPosition;
+  attribute vec2 aPosition;
   attribute vec3 aUV;
 
   uniform vec2 uResolution;
@@ -418,7 +411,7 @@ const vertexSrc = `
   varying vec3 vUV;
 
   void main() {
-    vec2 position = aVertexPosition * uScale + uOffset / uZoom;
+    vec2 position = aPosition * uScale + uOffset / uZoom;
     vec2 scaled = position * uZoom;
 
     vec2 clip = (scaled / uResolution) * 4.0 - 1.0;
@@ -435,8 +428,6 @@ const fragmentSrc = `
   varying vec3 vUV;
 
   void main() {
-    // gl_FragColor = vec4(color, 1.0);
-    // gl_FragColor = vec4(1.0);
     gl_FragColor = vec4(vUV, 1.0);
   }
 `
@@ -464,7 +455,7 @@ const BlockMesh = (xyz: XYZ) => Entity({
       zIndex: 10,
       anchor: { x: 0.5, y: 0.5 },
       setup: async (r) => {
-        const mesh = new Mesh({ geometry: blockGeometry(), shader })
+        const mesh = new Mesh({ geometry, shader })
 
         r.c = mesh
       },

--- a/core/src/ecs/entities/items/Block.ts
+++ b/core/src/ecs/entities/items/Block.ts
@@ -366,15 +366,6 @@ const blockGeometry = (): Geometry => {
     0.6, 0.3, 0.0,
   ])
 
-  const faceIds = new Float32Array([
-    // Top face
-    0, 0,
-    // Left face
-    1, 1,
-    // Right face
-    2, 2,
-  ])
-
   const positions = new Float32Array([
     // top
     0, 0,
@@ -406,7 +397,6 @@ const blockGeometry = (): Geometry => {
     9, 11, 10,
   ]
 
-  // geometry.addAttribute('aFaceId', faceIds)
   geometry.addAttribute('aVertexPosition', positions)
   geometry.addAttribute('aUV', uvs)
   geometry.addIndex(indices)

--- a/core/src/ecs/entities/items/Guns.ts
+++ b/core/src/ecs/entities/items/Guns.ts
@@ -25,7 +25,7 @@ export const GunItem = (name: string, gun: () => Gun): ItemBuilder => ({ id, cha
       anchor: { x: 0.5, y: 0.5 },
       interpolate: true,
       visible: false,
-      onTick:({ renderable, entity }) => {
+      onTick: ({ renderable, entity }) => {
         if (entity.components.item!.dropped) return
 
         const { pointing } = entity.components.position?.data ?? {}

--- a/core/src/ecs/entities/items/Guns.ts
+++ b/core/src/ecs/entities/items/Guns.ts
@@ -25,7 +25,7 @@ export const GunItem = (name: string, gun: () => Gun): ItemBuilder => ({ id, cha
       anchor: { x: 0.5, y: 0.5 },
       interpolate: true,
       visible: false,
-      dynamic: ({ renderable, entity }) => {
+      onTick:({ renderable, entity }) => {
         if (entity.components.item!.dropped) return
 
         const { pointing } = entity.components.position?.data ?? {}

--- a/core/src/ecs/entities/objects/Goal.ts
+++ b/core/src/ecs/entities/objects/Goal.ts
@@ -63,7 +63,7 @@ export const Goal = ({ color, position, id, width }: GoalProps): Entity => {
         sensor: sensor
       }),
       renderable: Renderable({
-        onTick:({ container }) => {
+        onTick: ({ container }) => {
           const t = container.children[1] as Text
           if (t) t.text = `${data.goals}`
         },

--- a/core/src/ecs/entities/objects/Goal.ts
+++ b/core/src/ecs/entities/objects/Goal.ts
@@ -63,7 +63,7 @@ export const Goal = ({ color, position, id, width }: GoalProps): Entity => {
         sensor: sensor
       }),
       renderable: Renderable({
-        dynamic: ({ container }) => {
+        onTick:({ container }) => {
           const t = container.children[1] as Text
           if (t) t.text = `${data.goals}`
         },

--- a/core/src/ecs/entities/terrain/Background.ts
+++ b/core/src/ecs/entities/terrain/Background.ts
@@ -17,7 +17,7 @@ export const Background = ({ img, json, rays, moving, follow }: BackgroundProps 
     renderable: Renderable({
       zIndex: -2,
       interpolate: true,
-      onTick:({ renderable, world, entity }) => {
+      onTick: ({ renderable, world, entity }) => {
         const godRayFilter = renderable.filters["rays"] as GodrayFilter
         if (rays && godRayFilter) godRayFilter.time += 0.008
 

--- a/core/src/ecs/entities/terrain/Background.ts
+++ b/core/src/ecs/entities/terrain/Background.ts
@@ -17,7 +17,7 @@ export const Background = ({ img, json, rays, moving, follow }: BackgroundProps 
     renderable: Renderable({
       zIndex: -2,
       interpolate: true,
-      dynamic: ({ renderable, world, entity }) => {
+      onTick:({ renderable, world, entity }) => {
         const godRayFilter = renderable.filters["rays"] as GodrayFilter
         if (rays && godRayFilter) godRayFilter.time += 0.008
 

--- a/core/src/ecs/entities/terrain/LineWall.ts
+++ b/core/src/ecs/entities/terrain/LineWall.ts
@@ -51,7 +51,7 @@ export const LineWall = (
       renderable: Renderable({
         visible: visible ?? false,
         zIndex: 3,
-        onTick:({ container }) => {
+        onTick: ({ container }) => {
           if (!wall.components.health) return
 
           const { hp, maxHp } = wall.components.health.data

--- a/core/src/ecs/entities/terrain/LineWall.ts
+++ b/core/src/ecs/entities/terrain/LineWall.ts
@@ -51,7 +51,7 @@ export const LineWall = (
       renderable: Renderable({
         visible: visible ?? false,
         zIndex: 3,
-        dynamic: ({ container }) => {
+        onTick:({ container }) => {
           if (!wall.components.health) return
 
           const { hp, maxHp } = wall.components.health.data

--- a/core/src/ecs/entities/ui/Chat.ts
+++ b/core/src/ecs/entities/ui/Chat.ts
@@ -7,7 +7,7 @@ export const Chat = (): Entity => {
     padding: 3,
     fontSize: 16,
     color: 0x55FFFF,
-    dynamic: ({ container, renderable, world }) => {
+    onTick:({ container, renderable, world }) => {
       const t = container as Text
 
       // hide chat if no recent messages
@@ -41,7 +41,7 @@ export const Chat = (): Entity => {
     color: 0xFFFF33,
     // boxOutline: true,
     // visible: false,
-    dynamic: ({ container }) => {
+    onTick:({ container }) => {
       const t = container as Text
       const textToRender = chatBuffer.join("")
       chatIsOpen ? t.text = `${textToRender}|` : t.text = ""

--- a/core/src/ecs/entities/ui/Chat.ts
+++ b/core/src/ecs/entities/ui/Chat.ts
@@ -7,7 +7,7 @@ export const Chat = (): Entity => {
     padding: 3,
     fontSize: 16,
     color: 0x55FFFF,
-    onTick:({ container, renderable, world }) => {
+    onTick: ({ container, renderable, world }) => {
       const t = container as Text
 
       // hide chat if no recent messages
@@ -41,7 +41,7 @@ export const Chat = (): Entity => {
     color: 0xFFFF33,
     // boxOutline: true,
     // visible: false,
-    onTick:({ container }) => {
+    onTick: ({ container }) => {
       const t = container as Text
       const textToRender = chatBuffer.join("")
       chatIsOpen ? t.text = `${textToRender}|` : t.text = ""

--- a/core/src/ecs/entities/ui/FpsText.ts
+++ b/core/src/ecs/entities/ui/FpsText.ts
@@ -14,7 +14,7 @@ export const FpsText = ({ x, y }: FpsTextProps = {}) => Entity<Position | Render
     renderable: Renderable({
       zIndex: 3,
       setContainer: async () => pixiText({ text: "", style: { fontSize: 16, fill: 0xffffff } }),
-      onTick:({ container, world }) => {
+      onTick: ({ container, world }) => {
         if (world.tick % 5 !== 0) return
 
         const t = container as Text

--- a/core/src/ecs/entities/ui/FpsText.ts
+++ b/core/src/ecs/entities/ui/FpsText.ts
@@ -13,8 +13,8 @@ export const FpsText = ({ x, y }: FpsTextProps = {}) => Entity<Position | Render
     position: Position({ x: x ?? 5, y: y ?? 25, screenFixed: true }),
     renderable: Renderable({
       zIndex: 3,
-      setContainer: async () => pixiText({ text: "", style: { fontSize: 16, fill: 0x00ff00 } }),
-      dynamic: ({ container, world }) => {
+      setContainer: async () => pixiText({ text: "", style: { fontSize: 16, fill: 0xffffff } }),
+      onTick:({ container, world }) => {
         if (world.tick % 5 !== 0) return
 
         const t = container as Text
@@ -40,7 +40,7 @@ export const LagText = ({ x, y }: FpsTextProps = {}) => {
       renderable: Renderable({
         zIndex: 3,
         setContainer: async () => pixiText({ text: "", style: { fontSize: 16, fill: 0x00ff00 } }),
-        dynamic: ({ container, world }) => {
+        onTick: ({ container, world }) => {
           lagText.components.renderable.visible = world.client?.connected ?? false
 
           const lag = round(world.client?.ms ?? 0)

--- a/core/src/ecs/entities/ui/Minimap.ts
+++ b/core/src/ecs/entities/ui/Minimap.ts
@@ -65,7 +65,7 @@ export const Minimap = (dim: number, tileMap: number[]): Entity => {
       }),
       renderable: Renderable({
         zIndex: 10,
-        dynamic: ({ world }) => {
+        onTick:({ world }) => {
 
           // remove dots that are no longer in the world
           keys(dots).forEach((id) => {

--- a/core/src/ecs/entities/ui/Minimap.ts
+++ b/core/src/ecs/entities/ui/Minimap.ts
@@ -65,7 +65,7 @@ export const Minimap = (dim: number, tileMap: number[]): Entity => {
       }),
       renderable: Renderable({
         zIndex: 10,
-        onTick:({ world }) => {
+        onTick: ({ world }) => {
 
           // remove dots that are no longer in the world
           keys(dots).forEach((id) => {

--- a/core/src/ecs/entities/ui/PvEHUD.ts
+++ b/core/src/ecs/entities/ui/PvEHUD.ts
@@ -40,7 +40,7 @@ export const PvEHUD = (): Entity => {
           renderable.c.removeChildren()
           renderable.c.addChild(...squares)
         },
-        onTick:async ({ container, world }) => {
+        onTick: async ({ container, world }) => {
           const playerCharacter = world.client?.playerCharacter()
           if (!playerCharacter) return
 

--- a/core/src/ecs/entities/ui/PvEHUD.ts
+++ b/core/src/ecs/entities/ui/PvEHUD.ts
@@ -40,7 +40,7 @@ export const PvEHUD = (): Entity => {
           renderable.c.removeChildren()
           renderable.c.addChild(...squares)
         },
-        dynamic: async ({ container, world }) => {
+        onTick:async ({ container, world }) => {
           const playerCharacter = world.client?.playerCharacter()
           if (!playerCharacter) return
 

--- a/core/src/ecs/entities/ui/PvPHUD.ts
+++ b/core/src/ecs/entities/ui/PvPHUD.ts
@@ -30,7 +30,7 @@ export const MobilePvPHUD = (): Entity => {
 
           renderable.c.addChild(outline, hp, ammo)
         },
-        onTick:({ world }) => {
+        onTick: ({ world }) => {
           const playerCharacter = world.client?.playerCharacter()
           if (!playerCharacter) return
 
@@ -96,7 +96,7 @@ export const PvPHUD = (keys: AbilityStrings, labels: AbilityStrings): Entity => 
 
           renderable.c.addChild(outline, hp, ammo, square1, square2, square3, square4, key1, key2, key3, key4, label1, label2, label3, label4)
         },
-        onTick:({ world }) => {
+        onTick: ({ world }) => {
           const playerCharacter = world.client?.playerCharacter()
           if (!playerCharacter) return
 

--- a/core/src/ecs/entities/ui/PvPHUD.ts
+++ b/core/src/ecs/entities/ui/PvPHUD.ts
@@ -30,7 +30,7 @@ export const MobilePvPHUD = (): Entity => {
 
           renderable.c.addChild(outline, hp, ammo)
         },
-        dynamic: ({ world }) => {
+        onTick:({ world }) => {
           const playerCharacter = world.client?.playerCharacter()
           if (!playerCharacter) return
 
@@ -96,7 +96,7 @@ export const PvPHUD = (keys: AbilityStrings, labels: AbilityStrings): Entity => 
 
           renderable.c.addChild(outline, hp, ammo, square1, square2, square3, square4, key1, key2, key3, key4, label1, label2, label3, label4)
         },
-        dynamic: ({ world }) => {
+        onTick:({ world }) => {
           const playerCharacter = world.client?.playerCharacter()
           if (!playerCharacter) return
 

--- a/core/src/ecs/entities/ui/ScorePanel.ts
+++ b/core/src/ecs/entities/ui/ScorePanel.ts
@@ -27,7 +27,7 @@ export const ScorePanel = (): Entity => {
       renderable: Renderable({
         zIndex: 10,
         anchor: { x: 0.5, y: 0 },
-        onTick:({ world }) => {
+        onTick: ({ world }) => {
           const state = world.game.state as { scoreLeft: number, scoreRight: number }
           if (left !== state.scoreLeft || right !== state.scoreRight) {
             left = state.scoreLeft

--- a/core/src/ecs/entities/ui/ScorePanel.ts
+++ b/core/src/ecs/entities/ui/ScorePanel.ts
@@ -27,7 +27,7 @@ export const ScorePanel = (): Entity => {
       renderable: Renderable({
         zIndex: 10,
         anchor: { x: 0.5, y: 0 },
-        dynamic: ({ world }) => {
+        onTick:({ world }) => {
           const state = world.game.state as { scoreLeft: number, scoreRight: number }
           if (left !== state.scoreLeft || right !== state.scoreRight) {
             left = state.scoreLeft

--- a/core/src/ecs/entities/ui/Scoreboard.ts
+++ b/core/src/ecs/entities/ui/Scoreboard.ts
@@ -24,7 +24,7 @@ export const Scoreboard = (): Entity => {
         visible: false,
         interactiveChildren: true,
         zIndex: 10,
-        dynamic: ({ world }) => {
+        onTick:({ world }) => {
           const currentPlayerEntities = world.queryEntities(["pc"]) as Player[]
           const currentPlayers = new Set(currentPlayerEntities.map((p) => ({ name: p.id, entity: p })))
 

--- a/core/src/ecs/entities/ui/Scoreboard.ts
+++ b/core/src/ecs/entities/ui/Scoreboard.ts
@@ -24,7 +24,7 @@ export const Scoreboard = (): Entity => {
         visible: false,
         interactiveChildren: true,
         zIndex: 10,
-        onTick:({ world }) => {
+        onTick: ({ world }) => {
           const currentPlayerEntities = world.queryEntities(["pc"]) as Player[]
           const currentPlayers = new Set(currentPlayerEntities.map((p) => ({ name: p.id, entity: p })))
 

--- a/core/src/ecs/entities/ui/Tooltip.ts
+++ b/core/src/ecs/entities/ui/Tooltip.ts
@@ -17,7 +17,7 @@ export const Tooltip = (id: string, text: string) => {
         visible: true,
         interactiveChildren: true,
         zIndex: 100,
-        dynamic: () => {
+        onTick:() => {
           if (!explainer || !explainerBg) return
 
           if (show <= 0) {

--- a/core/src/ecs/entities/ui/Tooltip.ts
+++ b/core/src/ecs/entities/ui/Tooltip.ts
@@ -17,7 +17,7 @@ export const Tooltip = (id: string, text: string) => {
         visible: true,
         interactiveChildren: true,
         zIndex: 100,
-        onTick:() => {
+        onTick: () => {
           if (!explainer || !explainerBg) return
 
           if (show <= 0) {

--- a/core/src/ecs/renderables/DebugBounds.ts
+++ b/core/src/ecs/renderables/DebugBounds.ts
@@ -3,7 +3,7 @@ import { Renderable, pixiGraphics } from "@piggo-gg/core"
 export const DebugBounds = (debugRenderable: Renderable): Renderable => {
 
   const renderable = Renderable({
-    onTick:({ container, renderable }) => {
+    onTick: ({ container, renderable }) => {
       container.position = { ...debugRenderable.position }
       renderable.visible = debugRenderable.visible
     },

--- a/core/src/ecs/renderables/DebugBounds.ts
+++ b/core/src/ecs/renderables/DebugBounds.ts
@@ -3,7 +3,7 @@ import { Renderable, pixiGraphics } from "@piggo-gg/core"
 export const DebugBounds = (debugRenderable: Renderable): Renderable => {
 
   const renderable = Renderable({
-    dynamic: ({ container, renderable }) => {
+    onTick:({ container, renderable }) => {
       container.position = { ...debugRenderable.position }
       renderable.visible = debugRenderable.visible
     },

--- a/core/src/ecs/renderables/HealthBar.ts
+++ b/core/src/ecs/renderables/HealthBar.ts
@@ -26,7 +26,7 @@ export const HealthBar = ({ health }: HealthBarProps): Renderable => {
   const renderable = Renderable({
     zIndex: 10,
     interpolate: true,
-    dynamic: () => {
+    onTick:() => {
       const { hp, maxHp } = health.data
 
       const healthPercent = hp / maxHp

--- a/core/src/ecs/renderables/HealthBar.ts
+++ b/core/src/ecs/renderables/HealthBar.ts
@@ -26,7 +26,7 @@ export const HealthBar = ({ health }: HealthBarProps): Renderable => {
   const renderable = Renderable({
     zIndex: 10,
     interpolate: true,
-    onTick:() => {
+    onTick: () => {
       const { hp, maxHp } = health.data
 
       const healthPercent = hp / maxHp

--- a/core/src/ecs/systems/core/PhysicsSystem.ts
+++ b/core/src/ecs/systems/core/PhysicsSystem.ts
@@ -104,7 +104,6 @@ export const PhysicsSystem = SystemBuilder({
 
         // update entity positions
         for (const [id, body] of entries(bodies)) {
-          // const body = bodies[id]
           const entity = world.entity<Collider | Position>(id)
           if (!entity) continue
 

--- a/core/src/ecs/systems/core/PhysicsSystem.ts
+++ b/core/src/ecs/systems/core/PhysicsSystem.ts
@@ -30,8 +30,6 @@ export const PhysicsSystem = SystemBuilder({
         // wait until rapier is ready
         if (!physics) return
 
-        const time = performance.now()
-
         // reset physics if not rollback
         if (!isRollback) resetPhysics()
 
@@ -97,7 +95,6 @@ export const PhysicsSystem = SystemBuilder({
             y: Math.floor(position.data.velocity.y * 100) / 100
           }, true)
         }
-        // console.log("Physics prep", performance.now() - time)
 
         // run physics
         physics.step()

--- a/core/src/ecs/systems/core/PhysicsSystem.ts
+++ b/core/src/ecs/systems/core/PhysicsSystem.ts
@@ -1,5 +1,5 @@
 import { init as RapierInit, World as RapierWorld, RigidBody } from "@dimforge/rapier2d-compat"
-import { Collider, Entity, Position, SystemBuilder, XYdistance, abs, keys, round } from "@piggo-gg/core"
+import { Collider, Entity, Position, SystemBuilder, XYdistance, abs, entries, keys, round } from "@piggo-gg/core"
 
 export let physics: RapierWorld
 RapierInit().then(() => physics = new RapierWorld({ x: 0, y: 0 }))
@@ -30,19 +30,18 @@ export const PhysicsSystem = SystemBuilder({
         // wait until rapier is ready
         if (!physics) return
 
-        // reset physics unless in rollback
+        const time = performance.now()
+
+        // reset physics if not rollback
         if (!isRollback) resetPhysics()
 
         // remove old bodies (TODO does this matter)
-        keys(bodies).forEach((id) => {
+        for (const id of keys(bodies)) {
           if (!world.entities[id]) {
             physics.removeRigidBody(bodies[id])
             delete bodies[id]
           }
-        })
-
-        // sort entities by id
-        entities.sort((a, b) => a.id > b.id ? 1 : -1)
+        }
 
         const groups: Set<string> = new Set()
 
@@ -54,12 +53,18 @@ export const PhysicsSystem = SystemBuilder({
           }
         }
 
+        // cull static colliders
+        entities = entities.filter((entity) => {
+          const { collider } = entity.components
+          return (collider.isStatic === false || !collider.cullable || groups.has(collider.group))
+        })
+
+        // sort entities by id
+        entities.sort((a, b) => a.id > b.id ? 1 : -1)
+
         // prepare physics bodies for each entity
         for (const entity of entities) {
           const { position, collider } = entity.components
-
-          // cull static colliders
-          if (collider.cullable && collider.isStatic && !groups.has(collider.group)) continue
 
           // handle new physics bodies
           if (!bodies[entity.id]) {
@@ -91,6 +96,7 @@ export const PhysicsSystem = SystemBuilder({
             y: Math.floor(position.data.velocity.y * 100) / 100
           }, true)
         }
+        console.log("Physics prep", performance.now() - time)
 
         // run physics
         physics.step()
@@ -99,10 +105,13 @@ export const PhysicsSystem = SystemBuilder({
         physics.step()
 
         // update entity positions
-        keys(bodies).forEach((id) => {
-          const body = bodies[id]
-          const { position } = world.entities[id].components
-          if (!position) return
+        for (const [id, body] of entries(bodies)) {
+          // const body = bodies[id]
+          const entity = world.entity<Collider | Position>(id)
+          if (!entity) continue
+
+          const { position, collider } = entity.components
+          if (collider.isStatic) continue
 
           // check if the entity has collided
           const diffX = position.data.velocity.x - Math.floor(body.linvel().x * 100) / 100
@@ -116,12 +125,12 @@ export const PhysicsSystem = SystemBuilder({
           position.data.y = round(body.translation().y * 100) / 100
           position.data.velocity.x = Math.floor(body.linvel().x * 100) / 100
           position.data.velocity.y = Math.floor(body.linvel().y * 100) / 100
-        })
+        }
 
         for (const [entity, collider] of colliders.entries()) {
 
           // check if standing
-          if (entity.components.position.data.friction && collider.rapierCollider) {
+          if (entity.components.position.data.friction && collider.rapierCollider && collider.isStatic === false) {
             let standing = false
 
             physics.contactPairsWith(collider.rapierCollider, (collider2) => {

--- a/core/src/ecs/systems/core/PhysicsSystem.ts
+++ b/core/src/ecs/systems/core/PhysicsSystem.ts
@@ -55,7 +55,8 @@ export const PhysicsSystem = SystemBuilder({
 
         // cull static colliders
         entities = entities.filter((entity) => {
-          const { collider } = entity.components
+          const { collider, renderable } = entity.components
+          if (renderable?.visible === false) return false
           return (collider.isStatic === false || !collider.cullable || groups.has(collider.group))
         })
 
@@ -96,7 +97,7 @@ export const PhysicsSystem = SystemBuilder({
             y: Math.floor(position.data.velocity.y * 100) / 100
           }, true)
         }
-        console.log("Physics prep", performance.now() - time)
+        // console.log("Physics prep", performance.now() - time)
 
         // run physics
         physics.step()

--- a/core/src/ecs/systems/ui/NametagSystem.ts
+++ b/core/src/ecs/systems/ui/NametagSystem.ts
@@ -77,7 +77,7 @@ const Nametag = (player: Player, character: Character) => {
       renderable: Renderable({
         zIndex: 10,
         interpolate: true,
-        onTick:async ({ renderable }) => {
+        onTick: async ({ renderable }) => {
           renderable.visible = character.components.renderable.visible
 
           if (player.components.pc.data.name !== name || player.components.team.data.team !== team) {

--- a/core/src/ecs/systems/ui/NametagSystem.ts
+++ b/core/src/ecs/systems/ui/NametagSystem.ts
@@ -77,7 +77,7 @@ const Nametag = (player: Player, character: Character) => {
       renderable: Renderable({
         zIndex: 10,
         interpolate: true,
-        dynamic: async ({ renderable }) => {
+        onTick:async ({ renderable }) => {
           renderable.visible = character.components.renderable.visible
 
           if (player.components.pc.data.name !== name || player.components.team.data.team !== team) {

--- a/core/src/ecs/systems/ui/RenderSystem.ts
+++ b/core/src/ecs/systems/ui/RenderSystem.ts
@@ -68,14 +68,14 @@ export const RenderSystem = ClientSystemBuilder({
           }
 
           // run dynamic callback
-          if (renderable.dynamic && renderable.initialized) renderable.dynamic({
+          if (renderable.onTick && renderable.initialized) renderable.onTick({
             container: renderable.c, entity, world, renderable, client: world.client!
           })
 
           // run dynamic callback for children
           if (renderable.children && renderable.initialized) {
             renderable.children.forEach((child) => {
-              if (child.dynamic) child.dynamic({ container: child.c, entity, world, renderable: child, client: world.client! })
+              if (child.onTick) child.onTick({ container: child.c, entity, world, renderable: child, client: world.client! })
             })
           }
 
@@ -160,16 +160,15 @@ export const RenderSystem = ClientSystemBuilder({
 
           const { position, renderable } = entity.components
 
+          if (renderable.onRender && renderable.initialized ) {
+            renderable.onRender({ container: renderable.c, entity, world, renderable, client: world.client! })
+          }
+
           if (!renderable.rendered || !renderable.interpolate) continue
 
           // ui renderables
           if (position.screenFixed) {
             updateScreenFixed(entity)
-          }
-
-          // todo
-          if (entity.id === "block-mesh") {
-            renderable.dynamic?.({ container: renderable.c, entity, world, renderable, client: world.client! })
           }
 
           // world renderables

--- a/core/src/ecs/systems/ui/RenderSystem.ts
+++ b/core/src/ecs/systems/ui/RenderSystem.ts
@@ -51,7 +51,7 @@ export const RenderSystem = ClientSystemBuilder({
           renderer.resizedFlag = false
         }
 
-        entities.forEach((entity) => {
+        for (const entity of entities) {
           const { position, renderable } = entity.components
 
           // render if skin changed
@@ -127,7 +127,7 @@ export const RenderSystem = ClientSystemBuilder({
 
           // set visible
           if (renderable.c.renderable !== renderable.visible) renderable.c.renderable = renderable.visible
-        })
+        }
 
         // sort entities by position (closeness to camera)
         const sortedEntityPositions = values(entities).sort((a, b) => (
@@ -146,26 +146,25 @@ export const RenderSystem = ClientSystemBuilder({
         })
 
         // update screenFixed entities
-        world.queryEntities<Renderable | Position>(["renderable", "position"]).forEach((entity) => {
+        for (const entity of world.queryEntities<Renderable | Position>(["renderable", "position"])) {
           updateScreenFixed(entity)
-        })
+        }
       },
       onRender(entities: Entity<Renderable | Position>[], delta) {
         for (const entity of entities) {
 
           const { position, renderable } = entity.components
 
-          if (!renderable.rendered) continue
+          if (!renderable.rendered || !renderable.interpolate) continue
 
           // ui renderables
           if (position.screenFixed) {
-            if (!renderable.interpolate) continue
             updateScreenFixed(entity)
           }
 
           // world renderables
           const { x, y, z, velocity } = position.data
-          if ((velocity.x || velocity.y || velocity.z) && renderable.interpolate) {
+          if ((velocity.x || velocity.y || velocity.z)) {
 
             const interpolated = position.interpolate(delta, world)
 

--- a/core/src/ecs/systems/ui/RenderSystem.ts
+++ b/core/src/ecs/systems/ui/RenderSystem.ts
@@ -56,7 +56,7 @@ export const RenderSystem = ClientSystemBuilder({
           const { position, renderable } = entity.components
 
           // render if skin changed
-          if (renderable.currentSkin !== renderable.data.desiredSkin) {
+          if (renderable.currentSkin && renderable.currentSkin !== renderable.data.desiredSkin) {
             renderable.c.removeChildren()
             renderable.rendered = false
           }
@@ -129,7 +129,8 @@ export const RenderSystem = ClientSystemBuilder({
           // set visible
           if (renderable.c.renderable !== renderable.visible) renderable.c.renderable = renderable.visible
         }
-        console.log("entity loop", performance.now() - time)
+        const loop = performance.now() - time
+        if (loop > 5) console.log("entity loop", performance.now() - time)
 
         const t = performance.now()
         // sort entities by position (closeness to camera)
@@ -140,7 +141,8 @@ export const RenderSystem = ClientSystemBuilder({
           // (a.components.position.data.y + a.components.position.data.z) -
           // (b.components.position.data.y + b.components.position.data.z)
         ))
-        console.log("sort", performance.now() - t)
+        const sort = performance.now() - t
+        if (sort > 5) console.log("sort loop", performance.now() - t)
 
         // set zIndex
         for (const [index, entity] of entities.entries()) {

--- a/core/src/ecs/systems/ui/RenderSystem.ts
+++ b/core/src/ecs/systems/ui/RenderSystem.ts
@@ -167,6 +167,11 @@ export const RenderSystem = ClientSystemBuilder({
             updateScreenFixed(entity)
           }
 
+          // todo
+          if (entity.id === "block-mesh") {
+            renderable.dynamic?.({ container: renderable.c, entity, world, renderable, client: world.client! })
+          }
+
           // world renderables
           const { x, y, z, velocity } = position.data
           if ((velocity.x || velocity.y || velocity.z)) {

--- a/core/src/graphics/Camera.ts
+++ b/core/src/graphics/Camera.ts
@@ -107,7 +107,7 @@ export const CameraSystem = (follow: Follow = ({ x, y }) => ({ x, y, z: 0 })) =>
     return {
       id: "CameraSystem",
       query: ["renderable", "position"],
-      priority: 10,
+      priority: 9,
       onTick: (entities: Entity<Renderable | Position>[]) => {
         // camera focus on player's character
         const character = world.client?.playerCharacter()

--- a/core/src/graphics/Renderer.ts
+++ b/core/src/graphics/Renderer.ts
@@ -50,7 +50,8 @@ export const Renderer = (canvas: HTMLCanvasElement): Renderer => {
         antialias: true,
         // autoDensity: true,
         backgroundColor: 0x000000,
-        preference: "webgl"
+        preference: "webgl",
+        depth: true
       })
 
       renderer.handleResize()

--- a/core/src/graphics/Renderer.ts
+++ b/core/src/graphics/Renderer.ts
@@ -48,8 +48,9 @@ export const Renderer = (canvas: HTMLCanvasElement): Renderer => {
         canvas,
         resolution: 1,
         antialias: true,
-        autoDensity: true,
-        backgroundColor: 0x000000
+        // autoDensity: true,
+        backgroundColor: 0x000000,
+        preference: "webgl"
       })
 
       renderer.handleResize()

--- a/core/src/graphics/Renderer.ts
+++ b/core/src/graphics/Renderer.ts
@@ -48,10 +48,9 @@ export const Renderer = (canvas: HTMLCanvasElement): Renderer => {
         canvas,
         resolution: 1,
         antialias: true,
-        // autoDensity: true,
+        autoDensity: true,
         backgroundColor: 0x000000,
-        preference: "webgl",
-        depth: true
+        preference: "webgl"
       })
 
       renderer.handleResize()

--- a/core/src/net/Netcode.ts
+++ b/core/src/net/Netcode.ts
@@ -24,12 +24,14 @@ export type GameData = {
 
 // API
 
-export type Request<Route extends string, Response extends {} = {}> = {
+export type Request<Route, Response extends {} = {}> = {
   type: "request"
   id: string
   route: Route
   response: { id: string, error: string } | { id: string } & Response
 }
+
+export type Route = RequestTypes["route"]
 
 export type RequestTypes =
   LobbyList | LobbyCreate | LobbyJoin | LobbyExit |

--- a/core/src/runtime/DefaultWorld.ts
+++ b/core/src/runtime/DefaultWorld.ts
@@ -11,6 +11,6 @@ export const DefaultWorld: WorldBuilder = (props: WorldProps) => World({
   systems: [
     RandomSystem, ExpiresSystem, ControlSystem, ClickableSystem, InputSystem, DebugSystem, ItemSystem,
     HealthSystem, CommandSystem, NPCSystem, NametagSystem, CooldownSystem,
-    PhysicsSystem, ActionSystem, EffectsSystem, PositionSystem, RenderSystem, MusicSystem
+    PhysicsSystem, ActionSystem, EffectsSystem, PositionSystem, RenderSystem
   ]
 })

--- a/core/src/runtime/World.ts
+++ b/core/src/runtime/World.ts
@@ -205,8 +205,8 @@ export const World = ({ commands, games, systems, renderer, mode }: WorldProps):
           system.onTick?.(filterEntities(system.query, values(world.entities)), isRollback)
 
           const ms = performance.now() - now
-          if (ms > 5) {
-            console.error(`System ${system.id} took ${ms}ms long to execute`)
+          if (ms > 7) {
+            console.error(`${system.id} took ${ms}ms`)
           }
         }
       })

--- a/core/src/runtime/World.ts
+++ b/core/src/runtime/World.ts
@@ -205,7 +205,7 @@ export const World = ({ commands, games, systems, renderer, mode }: WorldProps):
           system.onTick?.(filterEntities(system.query, values(world.entities)), isRollback)
 
           const ms = performance.now() - now
-          if (ms > 7) {
+          if (ms > 5) {
             console.error(`${system.id} took ${ms}ms`)
           }
         }

--- a/core/src/runtime/World.ts
+++ b/core/src/runtime/World.ts
@@ -150,8 +150,8 @@ export const World = ({ commands, games, systems, renderer, mode }: WorldProps):
       const c = Math.cos(a)
       const s = Math.sin(a)
 
-      let rx = (x * c - y * s)
-      let ry = (x * s + y * c)
+      const rx = (x * c - y * s)
+      const ry = (x * s + y * c)
 
       return { x: rx, y: ry }
     },

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -3,7 +3,8 @@ import {
   CameraSystem, InventorySystem, ShadowSystem, Background, SystemBuilder,
   Controlling, floor, BlockPreview, highestBlock, values, Cursor, Chat,
   EscapeMenu, intToBlock, max, round, XY, blocks, BlockMeshOcclusion,
-  BlockMesh, Position, Collider, Entity, XYZ, BlockCollider
+  BlockMesh, Position, Collider, Entity, XYZ, BlockCollider,
+  randomChoice
 } from "@piggo-gg/core"
 import { createNoise2D } from 'simplex-noise';
 
@@ -50,9 +51,9 @@ const spawnChunk = (chunk: XY) => {
   for (let i = 0; i < size; i++) {
     for (let j = 0; j < size; j++) {
       const xy = intToBlock(i + x * 4, j + y * 4)
-      const height = round(max(1, noise(xy.x / 400, xy.y / 400) * 12))
+      const height = round(max(1, noise(xy.x / 400, xy.y / 400) * 14))
       for (let k = 0; k < height; k++) {
-        const type = k > 0 ? "obsidian" : "grass"
+        const type = k > 10 ? "moonrock" : k == 0 ? "saphire" : "grass"
         blocks.add({ ...xy, z: k * 21, type })
       }
     }

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -2,7 +2,9 @@ import {
   SpawnSystem, isMobile, MobilePvEHUD, PvEHUD, Skelly, GameBuilder,
   CameraSystem, InventorySystem, ShadowSystem, Background, SystemBuilder,
   Controlling, floor, BlockPreview, highestBlock, values, Cursor, Chat,
-  EscapeMenu, World, Block, intToBlock, max, round, XY, snapXYToChunk, sqrt
+  EscapeMenu, World, Block, intToBlock, max, round, XY, snapXYToChunk, sqrt,
+  blocks,
+  BlockMesh
 } from "@piggo-gg/core"
 import { createNoise2D } from 'simplex-noise';
 
@@ -25,7 +27,8 @@ export const Craft: GameBuilder = {
       Background({ rays: true, follow: true }),
       Cursor(), Chat(), EscapeMenu(),
       isMobile() ? MobilePvEHUD() : PvEHUD(),
-      BlockPreview()
+      BlockPreview(),
+      BlockMesh()
     ]
   })
 }
@@ -54,8 +57,10 @@ const spawnChunk = (world: World, chunk: XY) => {
       const xy = intToBlock(i + x * 4, j + y * 4)
       const height = round(max(1, noise(xy.x / 300, xy.y / 300) * 10))
       for (let k = 0; k < height; k++) {
-        const block = Block({ ...xy, z: k * 21 }, k > 0 ? "obsidian" : "grass")
-        world.addEntity(block)
+        // const block = Block({ ...xy, z: k * 21 }, k > 0 ? "obsidian" : "grass")
+        // world.addEntity(block)
+
+        blocks.add({ ...xy, z: k * 21, type: "grass" })
       }
     }
   }
@@ -146,7 +151,7 @@ const CraftSystem = SystemBuilder({
             position.data.stop = highest
           } else {
             position.data.gravity = 0.3
-            position.data.stop = -600
+            position.data.stop = 0
           }
 
           if (position.data.z === -600) {

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -2,9 +2,8 @@ import {
   SpawnSystem, isMobile, MobilePvEHUD, PvEHUD, Skelly, GameBuilder,
   CameraSystem, InventorySystem, ShadowSystem, Background, SystemBuilder,
   Controlling, floor, BlockPreview, highestBlock, values, Cursor, Chat,
-  EscapeMenu, World, Block, intToBlock, max, round, XY, snapXYToChunk, sqrt,
-  blocks,
-  BlockMesh
+  EscapeMenu, World, intToBlock, max, round, XY, snapXYToChunk, sqrt,
+  blocks, BlockMesh
 } from "@piggo-gg/core"
 import { createNoise2D } from 'simplex-noise';
 

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -122,7 +122,7 @@ const CraftSystem = SystemBuilder({
 
                 const chunkDistance = sqrt((chunk.x - chunkX) ** 2 + (chunk.y - chunkY) ** 2)
                 if (chunkDistance > distance) {
-                  despawnChunk(world, { x: chunkX, y: chunkY })
+                  // despawnChunk(world, { x: chunkX, y: chunkY })
                 }
               }
 
@@ -131,7 +131,7 @@ const CraftSystem = SystemBuilder({
                 for (let j = -distance; j <= distance; j++) {
                   const newChunk = { x: chunk.x + i, y: chunk.y + j }
                   if (!liveChunks.has(`${newChunk.x}x${newChunk.y}`)) {
-                    spawnChunk(world, newChunk)
+                    // spawnChunk(world, newChunk)
                   }
                 }
               }

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -2,8 +2,9 @@ import {
   SpawnSystem, isMobile, MobilePvEHUD, PvEHUD, Skelly, GameBuilder,
   CameraSystem, InventorySystem, ShadowSystem, Background, SystemBuilder,
   Controlling, floor, BlockPreview, highestBlock, values, Cursor, Chat,
-  EscapeMenu, World, Block, intToBlock
+  EscapeMenu, World, Block, intToBlock, max, round
 } from "@piggo-gg/core"
+import { createNoise2D } from 'simplex-noise';
 
 export const Craft: GameBuilder = {
   id: "craft",
@@ -27,13 +28,21 @@ export const Craft: GameBuilder = {
   })
 }
 
-const size = 16
+const noise = createNoise2D(Math.random)
 const spawnTerrain = (world: World) => {
+  const size = 16
+
   for (let i = -size; i < size; i++) {
     for (let j = -size; j < size; j++) {
+
       const xy = intToBlock(i, j)
-      const block = Block({ ...xy, z: 0 }, "grass")
-      world.addEntity(block)
+
+      const height = round(max(1, noise(i / 40, j / 40) * 10))
+
+      for (let k = 0; k < height; k++) {
+        const block = Block({ ...xy, z: k * 21 }, k > 0 ? "obsidian" : "moss")
+        world.addEntity(block)
+      }
     }
   }
 }

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -2,11 +2,13 @@ import {
   SpawnSystem, isMobile, MobilePvEHUD, PvEHUD, Skelly, GameBuilder,
   CameraSystem, InventorySystem, ShadowSystem, Background, SystemBuilder,
   Controlling, floor, BlockPreview, highestBlock, values, Cursor, Chat,
-  EscapeMenu, intToBlock, max, round, XY, blocks, BlockMesh
+  EscapeMenu, intToBlock, max, round, XY, blocks,
+  BlockMeshOcclusion,
+  BlockMesh
 } from "@piggo-gg/core"
 import { createNoise2D } from 'simplex-noise';
-
 const noise = createNoise2D(Math.random)
+
 
 export const Craft: GameBuilder = {
   id: "craft",
@@ -26,7 +28,8 @@ export const Craft: GameBuilder = {
       Cursor(), Chat(), EscapeMenu(),
       isMobile() ? MobilePvEHUD() : PvEHUD(),
       BlockPreview(),
-      BlockMesh()
+      BlockMesh(),
+      BlockMeshOcclusion()
     ]
   })
 }

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -54,10 +54,7 @@ const spawnChunk = (chunk: XY) => {
       const xy = intToBlock(i + x * 4, j + y * 4)
       const height = round(max(1, noise(xy.x / 300, xy.y / 300) * 10))
       for (let k = 0; k < height; k++) {
-        // const block = Block({ ...xy, z: k * 21 }, k > 0 ? "obsidian" : "grass")
-        // world.addEntity(block)
-
-        blocks.add({ ...xy, z: k * 21, type: "grass" })
+        blocks.add({ ...xy, z: k * 21, type: k > 0 ? "obsidian" : "grass" })
       }
     }
   }
@@ -116,7 +113,7 @@ const CraftSystem = SystemBuilder({
           }
 
           if (position.data.z === -600) {
-            position.setPosition({ x: 0, y: 0, z: 128 })
+            position.setPosition({ x: 0, y: 200, z: 128 })
             position.setVelocity({ x: 0, y: 0, z: 0 })
           }
         }

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -3,8 +3,7 @@ import {
   CameraSystem, InventorySystem, ShadowSystem, Background, SystemBuilder,
   Controlling, floor, BlockPreview, highestBlock, values, Cursor, Chat,
   EscapeMenu, intToBlock, max, round, XY, blocks, BlockMeshOcclusion,
-  BlockMesh, Position, Collider, Entity, XYZ, BlockCollider,
-  randomChoice
+  BlockMesh, Position, Collider, Entity, XYZ, BlockCollider
 } from "@piggo-gg/core"
 import { createNoise2D } from 'simplex-noise';
 

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -6,6 +6,8 @@ import {
 } from "@piggo-gg/core"
 import { createNoise2D } from 'simplex-noise';
 
+const noise = createNoise2D(Math.random)
+
 export const Craft: GameBuilder = {
   id: "craft",
   init: () => ({
@@ -28,7 +30,6 @@ export const Craft: GameBuilder = {
   })
 }
 
-const noise = createNoise2D(Math.random)
 const spawnTerrain = (world: World) => {
   const size = 16
 
@@ -40,7 +41,7 @@ const spawnTerrain = (world: World) => {
       const height = round(max(1, noise(i / 40, j / 40) * 10))
 
       for (let k = 0; k < height; k++) {
-        const block = Block({ ...xy, z: k * 21 }, k > 0 ? "obsidian" : "moss")
+        const block = Block({ ...xy, z: k * 21 }, k > 0 ? "obsidian" : "grass")
         world.addEntity(block)
       }
     }

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -32,7 +32,7 @@ export const Craft: GameBuilder = {
 }
 
 const spawnTerrain = () => {
-  const num = 50
+  const num = 10
   for (let i = 0; i < num; i++) {
     for (let j = 0; j < num; j++) {
       const chunk = { x: i, y: j }

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -2,9 +2,7 @@ import {
   SpawnSystem, isMobile, MobilePvEHUD, PvEHUD, Skelly, GameBuilder,
   CameraSystem, InventorySystem, ShadowSystem, Background, SystemBuilder,
   Controlling, floor, BlockPreview, highestBlock, values, Cursor, Chat,
-  EscapeMenu, World, Block, intToBlock, max, round,
-  XY, randomChoice, BlockType, snapXYToChunk,
-  sqrt,
+  EscapeMenu, World, Block, intToBlock, max, round, XY, snapXYToChunk, sqrt
 } from "@piggo-gg/core"
 import { createNoise2D } from 'simplex-noise';
 
@@ -33,7 +31,7 @@ export const Craft: GameBuilder = {
 }
 
 const spawnTerrain = (world: World) => {
-  const num = 5
+  const num = 4
   for (let i = 0; i < num; i++) {
     for (let j = 0; j < num; j++) {
       const chunk = { x: i, y: j }
@@ -49,9 +47,6 @@ const liveChunks = new Set<Chunk>()
 const spawnChunk = (world: World, chunk: XY) => {
   const { x, y } = chunk
   liveChunks.add(`${x}x${y}`)
-
-  // const choice: BlockType[] = ["asteroid", "moonrock", "saphire", "ruby", "obsidian", "grass", "moss"]
-  // const color = randomChoice(choice)
 
   const size = 4
   for (let i = 0; i < size; i++) {
@@ -109,7 +104,7 @@ const CraftSystem = SystemBuilder({
 
           const chunk = snapXYToChunk({ x, y })
 
-          const distance = 3
+          const distance = 2
 
           if (playerChunks.has(character.id)) {
             const prevChunk = playerChunks.get(character.id)!

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -2,8 +2,7 @@ import {
   SpawnSystem, isMobile, MobilePvEHUD, PvEHUD, Skelly, GameBuilder,
   CameraSystem, InventorySystem, ShadowSystem, Background, SystemBuilder,
   Controlling, floor, BlockPreview, highestBlock, values, Cursor, Chat,
-  EscapeMenu, World, intToBlock, max, round, XY, snapXYToChunk, sqrt,
-  blocks, BlockMesh
+  EscapeMenu, World, intToBlock, max, round, XY, blocks, BlockMesh
 } from "@piggo-gg/core"
 import { createNoise2D } from 'simplex-noise';
 
@@ -33,7 +32,7 @@ export const Craft: GameBuilder = {
 }
 
 const spawnTerrain = () => {
-  const num = 20
+  const num = 50
   for (let i = 0; i < num; i++) {
     for (let j = 0; j < num; j++) {
       const chunk = { x: i, y: j }
@@ -44,7 +43,6 @@ const spawnTerrain = () => {
 
 type Chunk = `${number}x${number}`
 const liveChunks = new Set<Chunk>()
-// const liveChunks: Map<number, Map<number, true>> = new Map()
 
 const spawnChunk = (chunk: XY) => {
   const { x, y } = chunk
@@ -90,8 +88,6 @@ const CraftSystem = SystemBuilder({
 
     spawnTerrain()
 
-    const playerChunks = new Map<string, XY>()
-
     return {
       id: "CraftSystem",
       query: [],
@@ -105,40 +101,6 @@ const CraftSystem = SystemBuilder({
 
           const { position, collider } = character.components
           const { x, y, z, velocity } = position.data
-
-          const chunk = snapXYToChunk({ x, y })
-
-          const distance = 2
-
-          if (playerChunks.has(character.id)) {
-            const prevChunk = playerChunks.get(character.id)!
-            if (prevChunk.x !== chunk.x || prevChunk.y !== chunk.y) {
-              playerChunks.set(character.id, chunk)
-
-              // despawn previous chunk
-              for (const liveChunk of liveChunks) {
-                const [chunkX, chunkY] = liveChunk.split("x").map(Number)
-
-                const chunkDistance = sqrt((chunk.x - chunkX) ** 2 + (chunk.y - chunkY) ** 2)
-                if (chunkDistance > distance) {
-                  // despawnChunk(world, { x: chunkX, y: chunkY })
-                }
-              }
-
-              // spawn new chunk
-              for (let i = -distance; i <= distance; i++) {
-                for (let j = -distance; j <= distance; j++) {
-                  const newChunk = { x: chunk.x + i, y: chunk.y + j }
-                  if (!liveChunks.has(`${newChunk.x}x${newChunk.y}`)) {
-                    // spawnChunk(world, newChunk)
-                  }
-                }
-              }
-
-            }
-          } else {
-            playerChunks.set(character.id, chunk)
-          }
 
           // set collider group
           const group = (floor(z / 21) + 1).toString() as "1"

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -2,7 +2,7 @@ import {
   SpawnSystem, isMobile, MobilePvEHUD, PvEHUD, Skelly, GameBuilder,
   CameraSystem, InventorySystem, ShadowSystem, Background, SystemBuilder,
   Controlling, floor, BlockPreview, highestBlock, values, Cursor, Chat,
-  EscapeMenu, World, intToBlock, max, round, XY, blocks, BlockMesh
+  EscapeMenu, intToBlock, max, round, XY, blocks, BlockMesh
 } from "@piggo-gg/core"
 import { createNoise2D } from 'simplex-noise';
 
@@ -55,25 +55,6 @@ const spawnChunk = (chunk: XY) => {
       const height = round(max(1, noise(xy.x / 300, xy.y / 300) * 10))
       for (let k = 0; k < height; k++) {
         blocks.add({ ...xy, z: k * 21, type: k > 0 ? "obsidian" : "grass" })
-      }
-    }
-  }
-}
-
-const despawnChunk = (world: World, chunk: XY) => {
-  const { x, y } = chunk
-  const size = 4
-
-  liveChunks.delete(`${x}x${y}`)
-
-  for (let i = 0; i < size; i++) {
-    for (let j = 0; j < size; j++) {
-      const xy = intToBlock(x * 4 + i, y * 4 + j)
-
-      let z = 0
-      while (world.entity(`block-${xy.x}-${xy.y}-${z * 21}`)) {
-        world.removeEntity(`block-${xy.x}-${xy.y}-${z * 21}`)
-        z++
       }
     }
   }

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -32,12 +32,12 @@ export const Craft: GameBuilder = {
   })
 }
 
-const spawnTerrain = (world: World) => {
-  const num = 4
+const spawnTerrain = () => {
+  const num = 20
   for (let i = 0; i < num; i++) {
     for (let j = 0; j < num; j++) {
       const chunk = { x: i, y: j }
-      spawnChunk(world, chunk)
+      spawnChunk(chunk)
     }
   }
 }
@@ -46,7 +46,7 @@ type Chunk = `${number}x${number}`
 const liveChunks = new Set<Chunk>()
 // const liveChunks: Map<number, Map<number, true>> = new Map()
 
-const spawnChunk = (world: World, chunk: XY) => {
+const spawnChunk = (chunk: XY) => {
   const { x, y } = chunk
   liveChunks.add(`${x}x${y}`)
 
@@ -88,7 +88,7 @@ const CraftSystem = SystemBuilder({
   id: "CraftSystem",
   init: (world) => {
 
-    spawnTerrain(world)
+    spawnTerrain()
 
     const playerChunks = new Map<string, XY>()
 
@@ -145,12 +145,12 @@ const CraftSystem = SystemBuilder({
           collider.setGroup(group)
 
           // stop falling if directly above a block
-          const highest = highestBlock({ x, y }, world).z
+          const highest = highestBlock({ x, y }).z
           if (highest > 0 && z < (highest + 20) && velocity.z <= 0) {
             position.data.stop = highest
           } else {
             position.data.gravity = 0.3
-            position.data.stop = 0
+            position.data.stop = -600
           }
 
           if (position.data.z === -600) {

--- a/games/jump/Jump.ts
+++ b/games/jump/Jump.ts
@@ -138,7 +138,7 @@ export const Score = () => {
       renderable: Renderable({
         zIndex: 10,
         setContainer: async () => text,
-        onTick:({ world }) => {
+        onTick: ({ world }) => {
           const jumper = world.client?.playerCharacter()
           if (!jumper) return
 
@@ -166,7 +166,7 @@ const LeftBoundary = () => {
       debug: Debug(),
       renderable: Renderable({
         zIndex: 1,
-        onTick:({ world }) => {
+        onTick: ({ world }) => {
           const { x } = world.renderer!.camera.toCameraCoords({ x: 0, y: 0 })
           leftBoundary.components.position.setPosition({ x })
         },
@@ -187,7 +187,7 @@ const RightBoundary = () => {
       debug: Debug(),
       renderable: Renderable({
         zIndex: 1,
-        onTick:({ world }) => {
+        onTick: ({ world }) => {
           const { x } = world.renderer!.camera.toCameraCoords({ x: 300, y: 0 })
           rightBoundary.components.position.setPosition({ x })
         },

--- a/games/jump/Jump.ts
+++ b/games/jump/Jump.ts
@@ -138,7 +138,7 @@ export const Score = () => {
       renderable: Renderable({
         zIndex: 10,
         setContainer: async () => text,
-        dynamic: ({ world }) => {
+        onTick:({ world }) => {
           const jumper = world.client?.playerCharacter()
           if (!jumper) return
 
@@ -166,7 +166,7 @@ const LeftBoundary = () => {
       debug: Debug(),
       renderable: Renderable({
         zIndex: 1,
-        dynamic: ({ world }) => {
+        onTick:({ world }) => {
           const { x } = world.renderer!.camera.toCameraCoords({ x: 0, y: 0 })
           leftBoundary.components.position.setPosition({ x })
         },
@@ -187,7 +187,7 @@ const RightBoundary = () => {
       debug: Debug(),
       renderable: Renderable({
         zIndex: 1,
-        dynamic: ({ world }) => {
+        onTick:({ world }) => {
           const { x } = world.renderer!.camera.toCameraCoords({ x: 300, y: 0 })
           rightBoundary.components.position.setPosition({ x })
         },

--- a/games/lobby/Friends.ts
+++ b/games/lobby/Friends.ts
@@ -89,7 +89,7 @@ export const Friends = (): Entity => {
       renderable: Renderable({
         zIndex: 10,
         interactiveChildren: true,
-        onTick:({ world, client }) => {
+        onTick: ({ world, client }) => {
           if (!world.renderer) return
 
           const h = world.client?.token ? 200 : 290

--- a/games/lobby/Friends.ts
+++ b/games/lobby/Friends.ts
@@ -89,7 +89,7 @@ export const Friends = (): Entity => {
       renderable: Renderable({
         zIndex: 10,
         interactiveChildren: true,
-        dynamic: ({ world, client }) => {
+        onTick:({ world, client }) => {
           if (!world.renderer) return
 
           const h = world.client?.token ? 200 : 290

--- a/games/lobby/Lobby.ts
+++ b/games/lobby/Lobby.ts
@@ -60,7 +60,7 @@ const PlayerName = (player: Entity<PC | Team>, y: number) => {
         zIndex: 12,
         interactiveChildren: true,
         visible: false,
-        onTick:async ({ renderable, world }) => {
+        onTick: async ({ renderable, world }) => {
           if (pc.data.name !== lastName || team.data.team !== lastTeam) {
             renderable.c.removeChildren()
             renderable.c.addChild(text())

--- a/games/lobby/Lobby.ts
+++ b/games/lobby/Lobby.ts
@@ -60,7 +60,7 @@ const PlayerName = (player: Entity<PC | Team>, y: number) => {
         zIndex: 12,
         interactiveChildren: true,
         visible: false,
-        dynamic: async ({ renderable, world }) => {
+        onTick:async ({ renderable, world }) => {
           if (pc.data.name !== lastName || team.data.team !== lastTeam) {
             renderable.c.removeChildren()
             renderable.c.addChild(text())
@@ -138,7 +138,7 @@ const GameButton = (game: GameBuilder) => Entity<Position | Renderable>({
     renderable: Renderable({
       zIndex: 10,
       interactiveChildren: true,
-      dynamic: ({ world, renderable }) => {
+      onTick:({ world, renderable }) => {
         const state = world.game.state as LobbyState
         if (state.gameId === game.id) {
           renderable.setOutline({ color: 0xffff00, thickness: 2 })
@@ -240,7 +240,7 @@ const CreateLobbyButton = () => {
         zIndex: 10,
         interactiveChildren: true,
         anchor: { x: 0.5, y: 0.5 },
-        dynamic: ({ world }) => {
+        onTick:({ world }) => {
           const ready = (world.client?.ws.readyState ?? 0) === 1
           createLobbyButton.components.renderable.c.alpha = ready ? 1 : 0.6
           createLobbyButton.components.renderable.c.interactiveChildren = ready
@@ -294,7 +294,7 @@ const Avatar = (player: Entity<PC>, pos: XY, callback?: () => void) => {
         scaleMode: "nearest",
         animationSelect: () => "idle",
         interactiveChildren: true,
-        dynamic: ({ world }) => {
+        onTick:({ world }) => {
           if (!player.components.pc.data.name.startsWith("noob") && skin !== "ghost") {
             skin = "ghost"
             if (world.renderer) world.renderer.resizedFlag = true
@@ -337,7 +337,7 @@ const Profile = (): Entity => {
       position: Position({ x: 110, y: 85, screenFixed: true }),
       renderable: Renderable({
         zIndex: 10,
-        dynamic: ({ world }) => {
+        onTick:({ world }) => {
           const name = world.client?.playerName()
           if (name && playerName.text !== name) {
             playerName.text = name
@@ -373,7 +373,7 @@ const SignupCTA = () => Entity<Position | Renderable>({
       zIndex: 10,
       interactiveChildren: true,
       visible: false,
-      dynamic: ({ world, renderable }) => {
+      onTick:({ world, renderable }) => {
         if (!world.client) return
         renderable.visible = !world.client.token
       },
@@ -421,7 +421,7 @@ const PlayersOnline = () => {
           })
           renderable.c.addChild(text)
         },
-        dynamic: ({ world }) => {
+        onTick:({ world }) => {
           if (world.tick === 40 || world.tick % 200 === 0) refresh(world)
         }
       })

--- a/games/lobby/Lobby.ts
+++ b/games/lobby/Lobby.ts
@@ -138,7 +138,7 @@ const GameButton = (game: GameBuilder) => Entity<Position | Renderable>({
     renderable: Renderable({
       zIndex: 10,
       interactiveChildren: true,
-      onTick:({ world, renderable }) => {
+      onTick: ({ world, renderable }) => {
         const state = world.game.state as LobbyState
         if (state.gameId === game.id) {
           renderable.setOutline({ color: 0xffff00, thickness: 2 })
@@ -240,7 +240,7 @@ const CreateLobbyButton = () => {
         zIndex: 10,
         interactiveChildren: true,
         anchor: { x: 0.5, y: 0.5 },
-        onTick:({ world }) => {
+        onTick: ({ world }) => {
           const ready = (world.client?.ws.readyState ?? 0) === 1
           createLobbyButton.components.renderable.c.alpha = ready ? 1 : 0.6
           createLobbyButton.components.renderable.c.interactiveChildren = ready
@@ -294,7 +294,7 @@ const Avatar = (player: Entity<PC>, pos: XY, callback?: () => void) => {
         scaleMode: "nearest",
         animationSelect: () => "idle",
         interactiveChildren: true,
-        onTick:({ world }) => {
+        onTick: ({ world }) => {
           if (!player.components.pc.data.name.startsWith("noob") && skin !== "ghost") {
             skin = "ghost"
             if (world.renderer) world.renderer.resizedFlag = true
@@ -337,7 +337,7 @@ const Profile = (): Entity => {
       position: Position({ x: 110, y: 85, screenFixed: true }),
       renderable: Renderable({
         zIndex: 10,
-        onTick:({ world }) => {
+        onTick: ({ world }) => {
           const name = world.client?.playerName()
           if (name && playerName.text !== name) {
             playerName.text = name
@@ -373,7 +373,7 @@ const SignupCTA = () => Entity<Position | Renderable>({
       zIndex: 10,
       interactiveChildren: true,
       visible: false,
-      onTick:({ world, renderable }) => {
+      onTick: ({ world, renderable }) => {
         if (!world.client) return
         renderable.visible = !world.client.token
       },
@@ -421,7 +421,7 @@ const PlayersOnline = () => {
           })
           renderable.c.addChild(text)
         },
-        onTick:({ world }) => {
+        onTick: ({ world }) => {
           if (world.tick === 40 || world.tick % 200 === 0) refresh(world)
         }
       })

--- a/games/volley/Bot.ts
+++ b/games/volley/Bot.ts
@@ -140,7 +140,7 @@ export const Bot = (team: TeamNumber, pos: PositionProps): Entity<Position | Tea
         scaleMode: "nearest",
         setup: team === 1 ? DudeSkin("red") : DudeSkin("blue"),
         animationSelect: VolleyCharacterAnimations,
-        dynamic: VolleyCharacterDynamic
+        onTick:VolleyCharacterDynamic
       })
     }
   })

--- a/games/volley/Bot.ts
+++ b/games/volley/Bot.ts
@@ -140,7 +140,7 @@ export const Bot = (team: TeamNumber, pos: PositionProps): Entity<Position | Tea
         scaleMode: "nearest",
         setup: team === 1 ? DudeSkin("red") : DudeSkin("blue"),
         animationSelect: VolleyCharacterAnimations,
-        onTick:VolleyCharacterDynamic
+        onTick: VolleyCharacterDynamic
       })
     }
   })

--- a/games/volley/entities.ts
+++ b/games/volley/entities.ts
@@ -57,7 +57,7 @@ export const Dude = (player: Player) => Character({
         await Skins[r.data.desiredSkin ?? "dude-white"](r)
       },
       animationSelect: VolleyCharacterAnimations,
-      dynamic: VolleyCharacterDynamic
+      onTick:VolleyCharacterDynamic
     })
   }
 })
@@ -90,7 +90,7 @@ export const Ball = () => Entity({
       interpolate: true,
       scaleMode: "nearest",
       rotates: true,
-      dynamic: ({ entity: ball, world }) => {
+      onTick:({ entity: ball, world }) => {
         const { position: ballPos } = ball.components
         const { position, actions } = world.client?.playerCharacter()?.components ?? {}
         if (!position || !actions) return

--- a/games/volley/entities.ts
+++ b/games/volley/entities.ts
@@ -52,12 +52,12 @@ export const Dude = (player: Player) => Character({
       zIndex: 4,
       interpolate: true,
       scaleMode: "nearest",
-      skin: (player.components.pc.data.name.startsWith("noob")) ? "dude-white" : "ghost", 
+      skin: (player.components.pc.data.name.startsWith("noob")) ? "dude-white" : "ghost",
       setup: async (r) => {
         await Skins[r.data.desiredSkin ?? "dude-white"](r)
       },
       animationSelect: VolleyCharacterAnimations,
-      onTick:VolleyCharacterDynamic
+      onTick: VolleyCharacterDynamic
     })
   }
 })

--- a/games/volley/entities.ts
+++ b/games/volley/entities.ts
@@ -90,7 +90,7 @@ export const Ball = () => Entity({
       interpolate: true,
       scaleMode: "nearest",
       rotates: true,
-      onTick:({ entity: ball, world }) => {
+      onTick: ({ entity: ball, world }) => {
         const { position: ballPos } = ball.components
         const { position, actions } = world.client?.playerCharacter()?.components ?? {}
         if (!position || !actions) return

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT+CC",
   "dependencies": {
-    "typescript": "5.6.2"
+    "typescript": "5.8.3"
   },
   "devDependencies": {
     "copy-webpack-plugin": "11.0.0",

--- a/server/src/Api.ts
+++ b/server/src/Api.ts
@@ -38,7 +38,7 @@ export const Api = (): Api => {
 
   const prisma = new PrismaClient()
   const JWT_SECRET = process.env["JWT_SECRET"] ?? "piggo"
-  const client = new OAuth2Client("1064669120093-9727dqiidriqmrn0tlpr5j37oefqdam3.apps.googleusercontent.com")
+  const google = new OAuth2Client("1064669120093-9727dqiidriqmrn0tlpr5j37oefqdam3.apps.googleusercontent.com")
 
   const verifyJWT = (data: { token: string }): SessionToken | false => {
     let token: SessionToken | undefined = undefined
@@ -199,7 +199,7 @@ export const Api = (): Api => {
       "auth/login": async ({ ws, data }) => {
 
         // 1. verify google jwt
-        const ticket = await client.verifyIdToken({
+        const ticket = await google.verifyIdToken({
           idToken: data.jwt,
           audience: "1064669120093-9727dqiidriqmrn0tlpr5j37oefqdam3.apps.googleusercontent.com"
         })

--- a/web/src/components/Title.tsx
+++ b/web/src/components/Title.tsx
@@ -44,7 +44,7 @@ export const Title = ({ world, loginState, setLoginState }: TitleProps) => {
 
       <div style={{ position: 'absolute', right: 0, bottom: 0 }}>
         <span style={{ fontFamily: "sans-serif", fontSize: 14, marginRight: 5, verticalAlign: "-70%" }}>
-          v<b>0.16.6</b>
+          v<b>0.16.7</b>
         </span>
         <a style={{ margin: 0, color: "inherit", textDecoration: "none" }} target="_blank" href="https://discord.gg/VfFG9XqDpJ">
           <FaDiscord size={20} style={{ color: "white", verticalAlign: "-80%" }}></FaDiscord>

--- a/web/src/components/Title.tsx
+++ b/web/src/components/Title.tsx
@@ -44,7 +44,7 @@ export const Title = ({ world, loginState, setLoginState }: TitleProps) => {
 
       <div style={{ position: 'absolute', right: 0, bottom: 0 }}>
         <span style={{ fontFamily: "sans-serif", fontSize: 14, marginRight: 5, verticalAlign: "-70%" }}>
-          v<b>0.16.7</b>
+          v<b>0.17.1</b>
         </span>
         <a style={{ margin: 0, color: "inherit", textDecoration: "none" }} target="_blank" href="https://discord.gg/VfFG9XqDpJ">
           <FaDiscord size={20} style={{ color: "white", verticalAlign: "-80%" }}></FaDiscord>


### PR DESCRIPTION
refactored block rendering to improve performance (one entity per block was bad for rendering and RAM)

- blocks are no longer individual entities
- blocks are drawn by a custom shader
  - draw order is managed by multiple meshes
- block colliders are set dynamically 
- terrain is randomly generated with `simplex-noise`

|before|after|
|--|--|
|![sc](https://github.com/user-attachments/assets/44f05163-880d-4e49-ab27-79ccfeaa76f9)|<img width="1500" alt="Screenshot 2025-04-23 at 3 35 57 PM" src="https://github.com/user-attachments/assets/77ec6d80-f814-4a4b-98f4-b41719096da2" />
