### PR TITLE
v0.17.8 block placement refactor

### DIFF
--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -6,8 +6,8 @@ import {
 const { width, height } = BlockDimensions
 
 export type BlockData = {
+  atMouse: (mouse: XY) => XYZ | null
   add: (block: Block) => boolean
-  blockAtMouse: (mouse: XY) => XYZ | null
   data: (at: XY[]) => Block[]
   remove: (block: Block) => void
 }
@@ -31,6 +31,14 @@ export const BlockData = (): BlockData => {
   const chunkval = (x: number, y: number) => data[x]?.[y]
 
   const blocks: BlockData = {
+    atMouse: (mouse: XY) => {
+      let possibleX = Math.floor(mouse.x / width)
+      // possibleX -= randomInt(10) === 1 ? 0 : 0.5
+
+      const snapped = snapXYZ(mouse)
+      return { ...snapped, x: possibleX * width }
+      // return XYZtoChunk({ ...snapped, z: z.z })
+    },
     add: (block: Block) => {
       const chunkX = floor(block.x / 4)
       const chunkY = floor(block.y / 4)
@@ -61,14 +69,6 @@ export const BlockData = (): BlockData => {
       dirty[key] = true
 
       return true
-    },
-    blockAtMouse: (mouse: XY) => {
-      let possibleX = Math.floor(mouse.x / width)
-      // possibleX -= randomInt(10) === 1 ? 0 : 0.5
-
-      const snapped = snapXYZ(mouse)
-      return { ...snapped, x: possibleX * width }
-      // return XYZtoChunk({ ...snapped, z: z.z })
     },
     data: (at: XY[]) => {
       const result: Block[] = []

--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -20,7 +20,7 @@ export const BlockData = (): BlockData => {
   for (let i = 0; i < chunks; i++) {
     data[i] = []
     for (let j = 0; j < chunks; j++) {
-      data[i][j] = new Int8Array(4 * 4 * 16)
+      data[i][j] = new Int8Array(4 * 4 * 32)
     }
   }
 

--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -40,22 +40,33 @@ export const BlockData = (): BlockData => {
       if (!chunk) return null
 
       let found: Block | null = null
-      let dist = 1000
-      for (const block of chunk) {
+      // let dist = 1000
+
+      for (let i = chunk.length - 1; i >= 0; i--) {
+        const block = chunk[i]
         const { x, y, z } = block
 
-        const screenY = y - z
+        const screenY = y - z - height
 
-        if (x - mouse.x > width) continue
-        if (x - mouse.x < -width) continue
-
-        if (abs(screenY - mouse.y) > 10) continue
+        // if (x - mouse.x > width) continue
+        // if (x - mouse.x < -width) continue
+        // if (abs(screenY - mouse.y) > 10) continue
 
         const d = Math.sqrt((x - mouse.x) ** 2 + (screenY - mouse.y) ** 2)
-        if (d < dist) {
-          found = block
-          dist = d
-        }
+        if (d > width) continue
+
+        found = block
+        break
+
+
+
+
+        // if (d < dist) {
+        //   found = block
+        //   dist = d
+        // }
+
+
       }
 
       // console.log("found", found)
@@ -180,7 +191,7 @@ export const intToXYZ = (i: number, j: number, z: number): XYZ => {
 export const XYZtoIJK = (pos: XYZ): XYZ => {
   const snapped = XYtoIJ(pos)
   const z = floor(pos.z / 21)
-  
+
   return { x: snapped.x, y: snapped.y, z }
 }
 

--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -1,6 +1,6 @@
 import {
   BlockDimensions, Entity, floor, round, Block, World, XY, XYZ, Position,
-  BlockTree, randomInt, BlockType, BlockTypeInt, range, sample, logPerf, abs
+  BlockTree, randomInt, BlockType, BlockTypeInt, range, sample, logPerf
 } from "@piggo-gg/core"
 
 const { width, height } = BlockDimensions
@@ -40,7 +40,6 @@ export const BlockData = (): BlockData => {
       if (!chunk) return null
 
       let found: Block | null = null
-      // let dist = 1000
 
       for (let i = chunk.length - 1; i >= 0; i--) {
         const block = chunk[i]
@@ -48,28 +47,14 @@ export const BlockData = (): BlockData => {
 
         const screenY = y - z - height
 
-        // if (x - mouse.x > width) continue
-        // if (x - mouse.x < -width) continue
-        // if (abs(screenY - mouse.y) > 10) continue
-
+        // circle
         const d = Math.sqrt((x - mouse.x) ** 2 + (screenY - mouse.y) ** 2)
         if (d > width) continue
 
         found = block
         break
-
-
-
-
-        // if (d < dist) {
-        //   found = block
-        //   dist = d
-        // }
-
-
       }
 
-      // console.log("found", found)
       return found
     },
     add: (block: Block) => {

--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -1,6 +1,6 @@
 import {
-  BlockDimensions, Entity, floor, round, Block, World, XY, XYZ, Position,
-  BlockTree, randomInt, BlockType, BlockTypeInt, range, sample, logPerf
+  BlockDimensions, floor, round, Block, XY, XYZ, BlockTree, randomInt,
+  BlockType, BlockTypeInt, range, sample, logPerf
 } from "@piggo-gg/core"
 
 const { width, height } = BlockDimensions
@@ -239,70 +239,4 @@ export const highestBlock = (pos: XY, chunks: XY[]): XYZ => {
   }
 
   return { x: snapped.x, y: snapped.y, z: level }
-}
-
-// ------------------------------------
-
-// block[] at some X
-type XBlocks = Record<number, Entity<Position>[]>
-
-// todo move to an entity
-const xBlocksBuffer: XBlocks = {}
-
-const buildXBlocksBuffer = (world: World): XBlocks => {
-  const blocks = world.queryEntities<Position>(["position"], x => x.id.startsWith("block-"))
-
-  for (const block of blocks) {
-    const { x } = block.components.position.data
-    if (!xBlocksBuffer[x]) {
-      xBlocksBuffer[x] = []
-    }
-    xBlocksBuffer[x].push(block)
-  }
-
-  return xBlocksBuffer
-}
-
-const addToXBlocksBuffer = (block: Entity<Position>) => {
-  const { x } = block.components.position.data
-  if (!xBlocksBuffer[x]) {
-    xBlocksBuffer[x] = []
-  }
-  xBlocksBuffer[x].push(block)
-}
-
-// use the xBlocksBuffer to find the block at the mouse position
-const blockAtMouse = (mouse: XY): XYZ | null => {
-  const snapped = snapXY(mouse)
-
-  // sort by Z desc then Y desc
-  const blocks = xBlocksBuffer[snapped.x]
-  if (!blocks) return null
-
-  // sort by Z desc
-  blocks.sort((a, b) => {
-    const zA = a.components.position.data.z
-    const zB = b.components.position.data.z
-    return zB - zA
-  })
-
-  // sort by Y asc
-  blocks.sort((a, b) => {
-    const yA = a.components.position.data.y
-    const yB = b.components.position.data.y
-    return yB - yA
-  })
-
-  for (const block of blocks) {
-    const { x, y, z } = block.components.position.data
-
-    const bottom = y - z
-    const top = bottom - height - width
-
-    if (mouse.y <= bottom && mouse.y >= top) {
-      return { x, y, z }
-    }
-  }
-
-  return null
 }

--- a/core/src/ecs/entities/blocks/BlockItem.ts
+++ b/core/src/ecs/entities/blocks/BlockItem.ts
@@ -1,7 +1,10 @@
 import {
   Actions, BlockColors, BlockDimensions, blocks, BlockType, BlockTypeInt,
   Clickable, Effects, Item, ItemActionParams, ItemBuilder, ItemEntity,
-  pixiGraphics, Position, Renderable, snapXYZ
+  pixiGraphics, Position, Renderable, snapXYZ,
+  XYtoChunk,
+  XYtoIJ,
+  XYZtoChunk
 } from "@piggo-gg/core"
 import { Graphics } from "pixi.js"
 
@@ -31,7 +34,12 @@ export const BlockItem = (type: BlockType): ItemBuilder => ({ character, id }) =
         if (hold) return
         // addToXBlocksBuffer(block)
 
-        blocks.add({ ...snapXYZ(world.flip(mouse)), type: BlockTypeInt[type] })
+        const xyz = blocks.blockAtMouse(mouse)
+        if (!xyz) return
+        const spot = XYtoIJ(xyz)
+        blocks.add({ ...spot, z: 0, type: BlockTypeInt[type] })
+        console.log("BLOCK ADDED", xyz, type)
+        // blocks.add({ ...snapXYZ(world.flip(mouse)), type: BlockTypeInt[type] })
 
         world.client?.soundManager.play("click2")
       }

--- a/core/src/ecs/entities/blocks/BlockItem.ts
+++ b/core/src/ecs/entities/blocks/BlockItem.ts
@@ -37,7 +37,8 @@ export const BlockItem = (type: BlockType): ItemBuilder => ({ character, id }) =
         const xyz = blocks.blockAtMouse(mouse)
         if (!xyz) return
         const spot = XYtoIJ(xyz)
-        blocks.add({ ...spot, z: 0, type: BlockTypeInt[type] })
+        const added = blocks.add({ ...spot, z: 10, type: BlockTypeInt[type] })
+        if (!added) return
         console.log("BLOCK ADDED", xyz, type)
         // blocks.add({ ...snapXYZ(world.flip(mouse)), type: BlockTypeInt[type] })
 

--- a/core/src/ecs/entities/blocks/BlockItem.ts
+++ b/core/src/ecs/entities/blocks/BlockItem.ts
@@ -29,7 +29,6 @@ export const BlockItem = (type: BlockType): ItemBuilder => ({ character, id }) =
       mb1: ({ params, world, player }) => {
         const { hold, mouse } = params as ItemActionParams
         if (hold) return
-        // addToXBlocksBuffer(block)
 
         const character = player?.components.controlling.getCharacter(world)
         if (!character) return
@@ -38,11 +37,8 @@ export const BlockItem = (type: BlockType): ItemBuilder => ({ character, id }) =
         if (!xyz) return
 
         const spot = XYZtoIJK(xyz)
-        console.log("add block", xyz, spot)
         const added = blocks.add({ ...spot, z: spot.z + 1, type: BlockTypeInt[type] })
         if (!added) return
-
-        // blocks.add({ ...snapXYZ(world.flip(mouse)), type: BlockTypeInt[type] })
 
         world.client?.soundManager.play("click2")
       }

--- a/core/src/ecs/entities/blocks/BlockItem.ts
+++ b/core/src/ecs/entities/blocks/BlockItem.ts
@@ -1,11 +1,7 @@
 import {
   Actions, BlockColors, BlockDimensions, blocks, BlockType, BlockTypeInt,
   Clickable, Effects, Item, ItemActionParams, ItemBuilder, ItemEntity,
-  pixiGraphics, Position, Renderable, snapXYZ,
-  XYtoChunk,
-  XYtoIJ,
-  XYZtoChunk,
-  XYZtoIJK
+  pixiGraphics, Position, Renderable, XYZtoIJK
 } from "@piggo-gg/core"
 import { Graphics } from "pixi.js"
 

--- a/core/src/ecs/entities/blocks/BlockItem.ts
+++ b/core/src/ecs/entities/blocks/BlockItem.ts
@@ -4,7 +4,8 @@ import {
   pixiGraphics, Position, Renderable, snapXYZ,
   XYtoChunk,
   XYtoIJ,
-  XYZtoChunk
+  XYZtoChunk,
+  XYZtoIJK
 } from "@piggo-gg/core"
 import { Graphics } from "pixi.js"
 
@@ -29,17 +30,22 @@ export const BlockItem = (type: BlockType): ItemBuilder => ({ character, id }) =
   components: {
     position: Position({ follows: character?.id ?? "" }),
     actions: Actions({
-      mb1: ({ params, world }) => {
+      mb1: ({ params, world, player }) => {
         const { hold, mouse } = params as ItemActionParams
         if (hold) return
         // addToXBlocksBuffer(block)
 
-        const xyz = blocks.atMouse(mouse)
+        const character = player?.components.controlling.getCharacter(world)
+        if (!character) return
+
+        const xyz = blocks.atMouse(mouse, character.components.position.data)
         if (!xyz) return
-        const spot = XYtoIJ(xyz)
-        const added = blocks.add({ ...spot, z: 10, type: BlockTypeInt[type] })
+
+        const spot = XYZtoIJK(xyz)
+        console.log("add block", xyz, spot)
+        const added = blocks.add({ ...spot, z: spot.z + 1, type: BlockTypeInt[type] })
         if (!added) return
-        console.log("BLOCK ADDED", xyz, type)
+
         // blocks.add({ ...snapXYZ(world.flip(mouse)), type: BlockTypeInt[type] })
 
         world.client?.soundManager.play("click2")

--- a/core/src/ecs/entities/blocks/BlockItem.ts
+++ b/core/src/ecs/entities/blocks/BlockItem.ts
@@ -34,7 +34,7 @@ export const BlockItem = (type: BlockType): ItemBuilder => ({ character, id }) =
         if (hold) return
         // addToXBlocksBuffer(block)
 
-        const xyz = blocks.blockAtMouse(mouse)
+        const xyz = blocks.atMouse(mouse)
         if (!xyz) return
         const spot = XYtoIJ(xyz)
         const added = blocks.add({ ...spot, z: 10, type: BlockTypeInt[type] })

--- a/core/src/ecs/entities/blocks/BlockPreview.ts
+++ b/core/src/ecs/entities/blocks/BlockPreview.ts
@@ -1,4 +1,4 @@
-import { BlockDimensions, Entity, mouse, pixiGraphics, Position, Renderable, snapXYZ } from "@piggo-gg/core"
+import { BlockDimensions, blocks, Entity, mouse, pixiGraphics, Position, Renderable, snapXYZ } from "@piggo-gg/core"
 
 const { width, height } = BlockDimensions
 
@@ -25,8 +25,8 @@ export const BlockPreview = () => Entity({
         //   buildXBlocksBuffer(world)
         // }
 
-        const xyz = snapXYZ(world.flip(mouse))
-        // const xyz = blockAtMouse(mouse)
+        // const xyz = snapXYZ(world.flip(mouse))
+        const xyz = blocks.blockAtMouse(mouse)
 
         if (!xyz) {
           entity.components.renderable.visible = false

--- a/core/src/ecs/entities/blocks/BlockPreview.ts
+++ b/core/src/ecs/entities/blocks/BlockPreview.ts
@@ -25,14 +25,17 @@ export const BlockPreview = () => Entity({
         //   buildXBlocksBuffer(world)
         // }
 
+        const character = world.client?.playerCharacter()
+        if (!character) return
+
         // const xyz = snapXYZ(world.flip(mouse))
-        const xyz = blocks.atMouse(mouse)
+        const xyz = blocks.atMouse(mouse, character.components.position.data)
 
         if (!xyz) {
           entity.components.renderable.visible = false
         } else {
           entity.components.renderable.visible = true
-          entity.components.position.setPosition(xyz)
+          entity.components.position.setPosition({...xyz, z: xyz.z + 21})
         }
       },
       setup: async (r) => {

--- a/core/src/ecs/entities/blocks/BlockPreview.ts
+++ b/core/src/ecs/entities/blocks/BlockPreview.ts
@@ -1,4 +1,4 @@
-import { BlockDimensions, blocks, Entity, mouse, pixiGraphics, Position, Renderable, snapXYZ } from "@piggo-gg/core"
+import { BlockDimensions, blocks, Entity, mouse, pixiGraphics, Position, Renderable } from "@piggo-gg/core"
 
 const { width, height } = BlockDimensions
 
@@ -21,14 +21,9 @@ export const BlockPreview = () => Entity({
 
         if (!visible) return
 
-        // if (keys(xBlocksBuffer).length === 0) {
-        //   buildXBlocksBuffer(world)
-        // }
-
         const character = world.client?.playerCharacter()
         if (!character) return
 
-        // const xyz = snapXYZ(world.flip(mouse))
         const xyz = blocks.atMouse(mouse, character.components.position.data)
 
         if (!xyz) {

--- a/core/src/ecs/entities/blocks/BlockPreview.ts
+++ b/core/src/ecs/entities/blocks/BlockPreview.ts
@@ -26,7 +26,7 @@ export const BlockPreview = () => Entity({
         // }
 
         // const xyz = snapXYZ(world.flip(mouse))
-        const xyz = blocks.blockAtMouse(mouse)
+        const xyz = blocks.atMouse(mouse)
 
         if (!xyz) {
           entity.components.renderable.visible = false

--- a/core/src/ecs/entities/ui/EscapeMenu.ts
+++ b/core/src/ecs/entities/ui/EscapeMenu.ts
@@ -39,7 +39,7 @@ export const EscapeMenu = (): Entity => {
           text: "Return to Lobby",
           pos: { x: width / 2, y: (height / 2) - 100 },
           style: { fontSize },
-          width: 260
+          width: 300
         }),
         onClick: () => {
           world.actions.push(world.tick + 2, "world", { actionId: "game", params: { game: "lobby" } })
@@ -68,7 +68,7 @@ export const EscapeMenu = (): Entity => {
           text: "Settings",
           pos: { x: width / 2, y: (height / 2) - 45 },
           style: { fontSize },
-          width: 260
+          width: 300
         }),
         onClick: () => {
           console.log("Settings")

--- a/core/src/graphics/Camera.ts
+++ b/core/src/graphics/Camera.ts
@@ -12,6 +12,7 @@ export type Camera = {
   add: (r: Renderable) => void
   remove: (r: Renderable) => void
   scaleBy: (delta: number) => void
+  scaleTo: (scale: number) => void
   inFrame: (_: XY) => boolean
   moveBy: (_: XY) => void
   moveTo: (_: XY) => void
@@ -40,6 +41,10 @@ export const Camera = (app: Application): Camera => {
     },
     scaleBy: (delta: number) => {
       camera.scale += delta
+      rescale()
+    },
+    scaleTo: (scale: number) => {
+      camera.scale = scale
       rescale()
     },
     inFrame: ({ x, y }: XY) => { // TODO broken

--- a/core/src/net/Client.ts
+++ b/core/src/net/Client.ts
@@ -105,14 +105,14 @@ export const Client = ({ world }: ClientProps): Client => {
       if (client.lobbyId) {
         url = `${hosts[env]}/?join=${client.lobbyId}`
         navigator.clipboard.writeText(url)
-        toast.success(`Copied Invite URL`)
+        toast.success(`Copied Invite Link`)
       } else {
         client.lobbyCreate((response) => {
           if ("error" in response) return
 
           url = `${hosts[env]}/?join=${response.lobbyId}`
           navigator.clipboard.writeText(url)
-          toast.success(`Copied Invite URL`)
+          toast.success(`Copied Invite Link`)
         })
       }
     },

--- a/core/src/runtime/World.ts
+++ b/core/src/runtime/World.ts
@@ -22,7 +22,7 @@ export type World = {
   tick: number
   tickFlag: "green" | "red"
   tickrate: number
-  tileMap: number[] | undefined
+  tileMap: number[] | undefined // deprecated
   time: DOMHighResTimeStamp
   addEntities: (entities: Entity[]) => void
   addEntity: (entity: Entity, timeout?: number) => string | undefined
@@ -250,7 +250,10 @@ export const World = ({ commands, games, systems, renderer, mode }: WorldProps):
 
       world.tileMap = tileMap
 
-      world.renderer?.setBgColor(bgColor || 0x000000)
+      if (world.renderer) {
+        world.renderer.camera.scaleTo(2.5)
+        world.renderer.setBgColor(bgColor || 0x000000)
+      }
 
       // initialize new game
       world.addEntities(entities)

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
   <!-- social preview -->
   <meta property="og:title" content="Piggo" />
   <meta property="og:description" content="the funnest game on the web!" />
-  <meta property="og:image" content="https://piggo.gg/piggo-preview.png" />
+  <meta property="og:image" content="https://piggo.gg/piggo-profile-small.png" />
 
 </head>
 

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -55,8 +55,8 @@ const CraftSystem = SystemBuilder({
   id: "CraftSystem",
   init: (world) => {
 
-    // spawnTerrain()
-    spawnTiny()
+    spawnTerrain()
+    // spawnTiny()
 
     const blockColliders: Entity<Position | Collider>[] = [
       BlockCollider(0),

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -55,8 +55,8 @@ const CraftSystem = SystemBuilder({
   id: "CraftSystem",
   init: (world) => {
 
-    spawnTerrain()
-    // spawnTiny()
+    // spawnTerrain()
+    spawnTiny()
 
     const blockColliders: Entity<Position | Collider>[] = [
       BlockCollider(0),

--- a/games/lobby/Lobby.ts
+++ b/games/lobby/Lobby.ts
@@ -32,6 +32,7 @@ export const Lobby: GameBuilder = {
       Players(),
       PlayButton(),
       CreateLobbyButton(),
+      SettingsButton(),
       PlayersOnline()
     ],
     netcode: "delay"
@@ -276,6 +277,45 @@ const CreateLobbyButton = () => {
     }
   })
   return createLobbyButton
+}
+
+const SettingsButton = () => {
+  const settingsButton = Entity<Position>({
+    id: "settingsButton",
+    components: {
+      position: Position({ x: 300, y: 480, screenFixed: true }),
+      renderable: Renderable({
+        zIndex: 10,
+        interactiveChildren: true,
+        setup: async (r, renderer, world) => {
+          const { width } = renderer.wh()
+          settingsButton.components.position.setPosition({ x: 220 + (width - 230) / 2 })
+
+          r.setBevel({ rotation: 90, lightAlpha: 1, shadowAlpha: 0.3 })
+
+          const button = PixiButton({
+            content: () => ({
+              text: "Settings",
+              width: 260,
+              height: 40,
+              style: { fontSize: 26 }
+            }),
+            onClick: () => {
+              console.log("Settings")
+              world.client?.soundManager.play("click1", 0, undefined, true)
+            },
+            onEnter: () => {
+              r.setGlow({ outerStrength: 2 })
+              world.client?.soundManager.play("click3")
+            },
+            onLeave: () => r.setGlow()
+          })
+          r.c.addChild(button.c)
+        }
+      })
+    }
+  })
+  return settingsButton
 }
 
 const Avatar = (player: Entity<PC>, pos: XY, callback?: () => void) => {

--- a/games/lobby/Lobby.ts
+++ b/games/lobby/Lobby.ts
@@ -207,7 +207,7 @@ const PlayButton = () => {
           const button = PixiButton({
             content: () => ({
               text: "Play",
-              width: 260,
+              width: 300,
               height: 40,
               style: { fontSize: 26 }
             }),
@@ -255,7 +255,7 @@ const CreateLobbyButton = () => {
           const button = PixiButton({
             content: () => ({
               text: "Invite Friends",
-              width: 260,
+              width: 300,
               height: 40,
               style: { fontSize: 26 }
             }),
@@ -296,7 +296,7 @@ const SettingsButton = () => {
           const button = PixiButton({
             content: () => ({
               text: "Settings",
-              width: 260,
+              width: 300,
               height: 40,
               style: { fontSize: 26 }
             }),

--- a/games/lobby/Lobby.ts
+++ b/games/lobby/Lobby.ts
@@ -32,7 +32,7 @@ export const Lobby: GameBuilder = {
       Players(),
       PlayButton(),
       CreateLobbyButton(),
-      SettingsButton(),
+      // SettingsButton(),
       PlayersOnline()
     ],
     netcode: "delay"

--- a/web/src/components/Title.tsx
+++ b/web/src/components/Title.tsx
@@ -44,7 +44,7 @@ export const Title = ({ world, loginState, setLoginState }: TitleProps) => {
 
       <div style={{ position: 'absolute', right: 0, bottom: 0 }}>
         <span style={{ fontFamily: "sans-serif", fontSize: 14, marginRight: 5, verticalAlign: "-70%" }}>
-          v<b>0.17.7</b>
+          v<b>0.17.8</b>
         </span>
         <a style={{ margin: 0, color: "inherit", textDecoration: "none" }} target="_blank" href="https://discord.gg/VfFG9XqDpJ">
           <FaDiscord size={20} style={{ color: "white", verticalAlign: "-80%" }}></FaDiscord>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -27,7 +27,7 @@
   <!-- social preview -->
   <meta property="og:title" content="Piggo" />
   <meta property="og:description" content="the funnest game on the web!" />
-  <meta property="og:image" content="https://piggo.gg/piggo-preview.png" />
+  <meta property="og:image" content="https://piggo.gg/piggo-profile-small.png" />
 
 </head>
 


### PR DESCRIPTION
Craft
- added `BlockData.atMouse()`
- increased block height limit `16->32`
- updated how `BlockData.data` arranges blocks
  ```diff
  - const data: Record<string, Int8Array> = {}
  + const data: Int8Array[][] = []
  ```

Lobby
- buttons slightly wider `260 -> 300`

|before|after|
|--|--|
|<img width="405" alt="Screenshot 2025-05-05 at 7 17 04 PM" src="https://github.com/user-attachments/assets/3e6f885f-a832-4055-a112-f089b0d61a15" />|<img width="404" alt="Screenshot 2025-05-05 at 7 17 22 PM" src="https://github.com/user-attachments/assets/f5b52d0c-8143-4943-aaba-2f7f61e25ef8" />

