### PR TITLE
v0.17.10 fix camera flip

### DIFF
--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -1,6 +1,6 @@
 import {
   BlockDimensions, floor, round, Block, XY, XYZ, BlockTree, randomInt,
-  BlockType, BlockTypeInt, range, sample, logPerf, hypot, angleCC
+  BlockType, BlockTypeInt, range, sample, logPerf, hypot, angleCC, keys
 } from "@piggo-gg/core"
 
 const { width, height } = BlockDimensions
@@ -10,6 +10,7 @@ export type BlockData = {
   adjacent: (block: XY) => Block[] | null
   add: (block: Block) => boolean
   data: (at: XY[]) => Block[]
+  invalidate: () => void
   hasXYZ: (block: XYZ) => boolean
   remove: (block: Block) => void
 }
@@ -152,6 +153,11 @@ export const BlockData = (): BlockData => {
 
       logPerf("block data", time)
       return result
+    },
+    invalidate: () => {
+      for (const value of keys(dirty)) {
+        dirty[value] = true
+      }
     },
     hasXYZ: (block: XYZ) => {
       const chunk = XYtoChunk(block)

--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -108,7 +108,7 @@ export const BlockData = (): BlockData => {
       }
 
       if (data[chunkX][chunkY][index] !== 0) {
-        console.error("BLOCK ALREADY EXISTS", x, y, block.z)
+        // console.error("BLOCK ALREADY EXISTS", x, y, block.z)
         return false
       }
 

--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -123,11 +123,18 @@ export const BlockData = (): BlockData => {
       const result: Block[] = []
       const time = performance.now()
 
-      for (let atIndex = flip ? at.length - 1 : 0; flip ? atIndex >= 0 : atIndex < at.length; flip ? atIndex-- : atIndex++) {
-        const pos = at[atIndex]
+      const start = flip ? at.length - 1 : 0;
+      const end = flip ? -1 : at.length;
+      const step = flip ? -1 : 1;
+
+      for (let i = start; i !== end; i += step) {
+        const pos = at[i]
+
+        // chunk exists
         const chunk = chunkval(pos.x, pos.y)
         if (!chunk) continue
 
+        // read the cache
         const key = `${pos.x}:${pos.y}`
         if (cache[key] && !dirty[key]) {
           result.push(...cache[key])
@@ -136,6 +143,7 @@ export const BlockData = (): BlockData => {
 
         const chunkResult: Block[] = []
 
+        // find blocks in the chunk
         for (let z = 0; z < 32; z++) {
           for (let y = flip ? 3 : 0; flip ? y >= 0 : y < 4; flip ? y-- : y++) {
             for (let x = flip ? 3 : 0; flip ? x >= 0 : x < 4; flip ? x-- : x++) {

--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -9,7 +9,7 @@ export type BlockData = {
   atMouse: (mouse: XY, player: XYZ) => XYZ | null
   adjacent: (block: XY) => Block[] | null
   add: (block: Block) => boolean
-  data: (at: XY[]) => Block[]
+  data: (at: XY[], flip?: boolean) => Block[]
   invalidate: () => void
   hasXYZ: (block: XYZ) => boolean
   remove: (block: Block) => void
@@ -119,11 +119,12 @@ export const BlockData = (): BlockData => {
 
       return true
     },
-    data: (at: XY[]) => {
+    data: (at: XY[], flip: boolean = false) => {
       const result: Block[] = []
       const time = performance.now()
 
-      for (const pos of at) {
+      for (let atIndex = flip ? at.length - 1 : 0; flip ? atIndex >= 0 : atIndex < at.length; flip ? atIndex-- : atIndex++) {
+        const pos = at[atIndex]
         const chunk = chunkval(pos.x, pos.y)
         if (!chunk) continue
 
@@ -136,19 +137,14 @@ export const BlockData = (): BlockData => {
         const chunkResult: Block[] = []
 
         for (let z = 0; z < 32; z++) {
-          for (let y = 0; y < 4; y++) {
-            for (let x = 0; x < 4; x++) {
+          for (let y = flip ? 3 : 0; flip ? y >= 0 : y < 4; flip ? y-- : y++) {
+            for (let x = flip ? 3 : 0; flip ? x >= 0 : x < 4; flip ? x-- : x++) {
 
               const index = z * 16 + y * 4 + x
               const type = chunk[index]
               if (type === 0) continue
 
-              const xyz = intToXYZ(
-                x + pos.x * 4,
-                y + pos.y * 4,
-                z
-              )
-
+              const xyz = intToXYZ(x + pos.x * 4, y + pos.y * 4, z)
               const block: Block = { ...xyz, type }
               chunkResult.push(block)
             }

--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -135,16 +135,24 @@ export const BlockData = (): BlockData => {
 
         const chunkResult: Block[] = []
 
-        for (let i = 0; i < chunk.length; i++) {
-          const type = chunk[i]
-          if (type === 0) continue
+        for (let z = 0; z < 32; z++) {
+          for (let y = 0; y < 4; y++) {
+            for (let x = 0; x < 4; x++) {
 
-          let x = pos.x * 4 + i % 4
-          let y = pos.y * 4 + floor((i % 16) / 4)
-          let z = floor(i / 16)
+              const index = z * 16 + y * 4 + x
+              const type = chunk[index]
+              if (type === 0) continue
 
-          const block: Block = { ...intToXYZ(x, y, z), type }
-          chunkResult.push(block)
+              const xyz = intToXYZ(
+                x + pos.x * 4,
+                y + pos.y * 4,
+                z
+              )
+
+              const block: Block = { ...xyz, type }
+              chunkResult.push(block)
+            }
+          }
         }
         cache[key] = chunkResult
         dirty[key] = false

--- a/core/src/ecs/entities/blocks/BlockMesh.ts
+++ b/core/src/ecs/entities/blocks/BlockMesh.ts
@@ -44,12 +44,12 @@ export const BlockMesh = (type: "foreground" | "background") => {
             }
           }
 
-          // if (world.flipped() !== flipped) {
-          //   flipped = world.flipped()
-          //   blocks.invalidate()
-          // }
+          if (world.flipped() !== flipped) {
+            flipped = world.flipped()
+            blocks.invalidate()
+          }
 
-          chunkData = blocks.data(chunks)
+          chunkData = blocks.data(chunks, flipped === -1)
         },
         onRender: ({ world, delta, renderable }) => {
           const time = performance.now()

--- a/core/src/ecs/entities/blocks/BlockMesh.ts
+++ b/core/src/ecs/entities/blocks/BlockMesh.ts
@@ -15,6 +15,8 @@ export const BlockMesh = (type: "foreground" | "background") => {
   let chunkData: Block[] = []
   let topBlocks: Block[] = [{ x: 9, y: 9, z: 1, type: 2 }]
 
+  let flipped = 1
+
   return Entity({
     id: `block-mesh-${type}`,
     components: {
@@ -41,6 +43,11 @@ export const BlockMesh = (type: "foreground" | "background") => {
               chunks.push({ x: playerChunk.x + x, y: playerChunk.y + y })
             }
           }
+
+          // if (world.flipped() !== flipped) {
+          //   flipped = world.flipped()
+          //   blocks.invalidate()
+          // }
 
           chunkData = blocks.data(chunks)
         },
@@ -77,9 +84,11 @@ export const BlockMesh = (type: "foreground" | "background") => {
           const newColorBuffer = new Float32Array(chunkData.length * 3)
 
           let instanceCount = 0
-          for (const block of chunkData) {
-            // const { x, y } = world.flip(block)
-            const { x, y } = block
+
+          for (let i = 0; i < chunkData.length; i++) {
+            const block = chunkData[i]
+            // const block = flipped ? chunkData[chunkData.length - 1 - i] : chunkData[i]
+            const { x, y } = world.flip(block)
 
             const blockInFront = (y - playerY) > 0
 

--- a/core/src/ecs/entities/blocks/BlockMesh.ts
+++ b/core/src/ecs/entities/blocks/BlockMesh.ts
@@ -110,7 +110,7 @@ export const BlockMesh = (type: "foreground" | "background") => {
           geometry.instanceCount = instanceCount
 
           renderable.c.visible = instanceCount > 0
-          logPerf("block mesh", time)
+          logPerf("block mesh", time, 9)
         }
       })
     }

--- a/core/src/ecs/entities/blocks/BlockMesh.ts
+++ b/core/src/ecs/entities/blocks/BlockMesh.ts
@@ -85,9 +85,7 @@ export const BlockMesh = (type: "foreground" | "background") => {
 
           let instanceCount = 0
 
-          for (let i = 0; i < chunkData.length; i++) {
-            const block = chunkData[i]
-            // const block = flipped ? chunkData[chunkData.length - 1 - i] : chunkData[i]
+          for (const block of chunkData) {
             const { x, y } = world.flip(block)
 
             const blockInFront = (y - playerY) > 0

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -55,8 +55,8 @@ const CraftSystem = SystemBuilder({
   id: "CraftSystem",
   init: (world) => {
 
-    // spawnTerrain()
-    spawnTiny()
+    spawnTerrain()
+    // spawnTiny()
 
     const blockColliders: Entity<Position | Collider>[] = [
       BlockCollider(0),

--- a/games/craft/Craft.ts
+++ b/games/craft/Craft.ts
@@ -55,8 +55,8 @@ const CraftSystem = SystemBuilder({
   id: "CraftSystem",
   init: (world) => {
 
-    spawnTerrain()
-    // spawnTiny()
+    // spawnTerrain()
+    spawnTiny()
 
     const blockColliders: Entity<Position | Collider>[] = [
       BlockCollider(0),

--- a/web/src/components/Title.tsx
+++ b/web/src/components/Title.tsx
@@ -44,7 +44,7 @@ export const Title = ({ world, loginState, setLoginState }: TitleProps) => {
 
       <div style={{ position: 'absolute', right: 0, bottom: 0 }}>
         <span style={{ fontFamily: "sans-serif", fontSize: 14, marginRight: 5, verticalAlign: "-70%" }}>
-          v<b>0.17.9</b>
+          v<b>0.17.10</b>
         </span>
         <a style={{ margin: 0, color: "inherit", textDecoration: "none" }} target="_blank" href="https://discord.gg/VfFG9XqDpJ">
           <FaDiscord size={20} style={{ color: "white", verticalAlign: "-80%" }}></FaDiscord>


### PR DESCRIPTION
in Craft, pressing `q` to flip the camera has been broken since refactoring the block rendering to a custom shader

now it's fixed. remaining TODO is to fix block placement while flipped (`camera.root` issue)