### PR TITLE
v0.19.2 improve block outline

### DIFF
--- a/core/src/ecs/entities/blocks/BlockShader.ts
+++ b/core/src/ecs/entities/blocks/BlockShader.ts
@@ -139,22 +139,22 @@ const fragmentSrc = `
     ) {
       if (face == 0) {
 
-        bool isEdge = vBary.x < 0.01 || vBary.y < 0.01 || vBary.z < 0.01;
-        bool isCenter = abs(vOffset.x) < 0.2;
+        bool isEdge = vBary.x < 0.02 || vBary.y < 0.02 || vBary.z < 0.02;
+        bool isCenter = abs(vOffset.x) < 0.4 && abs(vOffset.y) < 8.6;
 
         if (!isCenter && isEdge) {
-          fragColor = vec4(0.0, 0.0, 0.0, 1.0);
+          fragColor = vec4(0.0, 0.0, 0.6, 1.0);
           return;
         }
       } else {
 
-        bool isCenter = abs(vOffset.x) < 0.2;
-        bool isSide = abs(vOffset.x) > 17.8;
-        bool isTop = abs(vOffset.z) > 20.8;
-        bool isBottom = abs(vOffset.z) < 0.2;
+        bool isCenter = abs(vOffset.x) < 0.4;
+        bool isSide = abs(vOffset.x) > 17.6;
+        bool isTop = abs(vOffset.z) > 20.6;
+        bool isBottom = abs(vOffset.z) < 0.4;
 
         if (isCenter || isSide || isTop || isBottom) {
-          fragColor = vec4(0.0, 0.0, 0.0, 1.0);
+          fragColor = vec4(0.0, 0.0, 0.6, 1.0);
           return;
         }
       }

--- a/web/src/components/Title.tsx
+++ b/web/src/components/Title.tsx
@@ -44,7 +44,7 @@ export const Title = ({ world, loginState, setLoginState }: TitleProps) => {
 
       <div style={{ position: 'absolute', right: 0, bottom: 0 }}>
         <span style={{ fontFamily: "sans-serif", fontSize: 14, marginRight: 5, verticalAlign: "-70%" }}>
-          v<b>0.19.1</b>
+          v<b>0.19.2</b>
         </span>
         <a style={{ margin: 0, color: "inherit", textDecoration: "none" }} target="_blank" href="https://discord.gg/VfFG9XqDpJ">
           <FaDiscord size={20} style={{ color: "white", verticalAlign: "-80%" }}></FaDiscord>


### PR DESCRIPTION
block select outline is now thicker, dark blue, and has no gaps on the top face

|before|after|
|--|--|
|<img width="440" alt="Screenshot 2025-05-20 at 11 32 25 AM" src="https://github.com/user-attachments/assets/e9171b48-6885-472c-8ae8-f5ac13c0f8ba" />|<img width="415" alt="Screenshot 2025-05-20 at 11 33 04 AM" src="https://github.com/user-attachments/assets/50d99b9e-cead-495d-a8fa-a156d51f2d88" />
