### PR TITLE
v0.19.6 block render culling

### DIFF
--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -272,10 +272,6 @@ export const BlockData = (): BlockData => {
           dirty[value] = true
         }
       }
-
-      // for (const value of keys(dirty)) {
-      //   dirty[value] = true
-      // }
     },
     hasXYZ: (block: XYZ) => {
       const chunk = XYtoChunk(block)

--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -39,6 +39,20 @@ export const BlockData = (): BlockData => {
   const chunkey = (x: number, y: number) => `${x}:${y}`
   const chunkval = (x: number, y: number) => data[x]?.[y]
 
+  const val = (x: number, y: number, z: number) => {
+    const chunkX = floor(x / 4)
+    const chunkY = floor(y / 4)
+
+    const chunk = chunkval(chunkX, chunkY)
+    if (!chunk) return chunk
+
+    const xIndex = x - chunkX * 4
+    const yIndex = y - chunkY * 4
+    const index = z * 16 + yIndex * 4 + xIndex
+
+    return chunk[index]
+  }
+
   const blocks: BlockData = {
     atMouse: (mouse: XY, player: XYZ) => {
       const playerChunk = XYtoChunk(player)
@@ -205,9 +219,21 @@ export const BlockData = (): BlockData => {
 
               // cull unless z+1 or x+1 or y+1 are empty
               // const zAbove = chunk[index + 16]
-              if (chunk[index + 16] === 0 || chunk[index + 1] === 0 || chunk[index + 4] === 0) {
+              // const zUp = index + 16
+              // const xUp = flip ? index - 1 : index + 1
+              // const yUp = flip ? index - 4 : index + 4
 
+              // const checkX = flip ? x - 1 : x + 1
+              // const checkY = flip ? y - 4 : y + 4
+              // const checkZ = z + 16
 
+              const dir = flip ? -1 : 1
+
+              if (
+                !val(pos.x * 4 + x + dir, pos.y * 4 + y, z) ||
+                !val(pos.x * 4 + x, pos.y * 4 + y + dir, z) ||
+                !val(pos.x * 4 + x, pos.y * 4 + y, z + 1)
+              ) {
                 const xyz = intToXYZ(x + pos.x * 4, y + pos.y * 4, z)
                 const block: Block = { ...xyz, type }
                 chunkResult.push(block)

--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -216,17 +216,6 @@ export const BlockData = (): BlockData => {
               const type = chunk[index]
               if (type === 0) continue
 
-
-              // cull unless z+1 or x+1 or y+1 are empty
-              // const zAbove = chunk[index + 16]
-              // const zUp = index + 16
-              // const xUp = flip ? index - 1 : index + 1
-              // const yUp = flip ? index - 4 : index + 4
-
-              // const checkX = flip ? x - 1 : x + 1
-              // const checkY = flip ? y - 4 : y + 4
-              // const checkZ = z + 16
-
               const dir = flip ? -1 : 1
 
               if (

--- a/core/src/ecs/entities/blocks/BlockData.ts
+++ b/core/src/ecs/entities/blocks/BlockData.ts
@@ -163,7 +163,9 @@ export const BlockData = (): BlockData => {
       data[chunkX][chunkY][index] = block.type
 
       const key = chunkey(chunkX, chunkY)
+
       dirty[key] = true
+      culledDirty[key] = true
 
       return true
     },
@@ -200,9 +202,16 @@ export const BlockData = (): BlockData => {
               const type = chunk[index]
               if (type === 0) continue
 
-              const xyz = intToXYZ(x + pos.x * 4, y + pos.y * 4, z)
-              const block: Block = { ...xyz, type }
-              chunkResult.push(block)
+
+              // cull unless z+1 or x+1 or y+1 are empty
+              // const zAbove = chunk[index + 16]
+              if (chunk[index + 16] === 0 || chunk[index + 1] === 0 || chunk[index + 4] === 0) {
+
+
+                const xyz = intToXYZ(x + pos.x * 4, y + pos.y * 4, z)
+                const block: Block = { ...xyz, type }
+                chunkResult.push(block)
+              }
             }
           }
         }
@@ -322,7 +331,9 @@ export const BlockData = (): BlockData => {
       data[chunkX][chunkY][index] = 0
 
       const key = chunkey(chunkX, chunkY)
+
       dirty[key] = true
+      culledDirty[key] = true
     }
   }
 

--- a/core/src/ecs/entities/blocks/BlockMesh.ts
+++ b/core/src/ecs/entities/blocks/BlockMesh.ts
@@ -46,12 +46,10 @@ export const BlockMesh = (type: "foreground" | "background") => {
 
           if (world.flipped() !== flipped) {
             flipped = world.flipped()
-            blocks.invalidate()
+            blocks.invalidate("culledCache")
           }
 
-          chunkData = blocks.data(chunks, flipped === -1)
-
-          console.log("chunkData", chunkData.length)
+          chunkData = blocks.culled(chunks, flipped === -1)
         },
         onRender: ({ world, delta, renderable }) => {
           const time = performance.now()

--- a/core/src/ecs/entities/blocks/BlockMesh.ts
+++ b/core/src/ecs/entities/blocks/BlockMesh.ts
@@ -46,10 +46,10 @@ export const BlockMesh = (type: "foreground" | "background") => {
 
           if (world.flipped() !== flipped) {
             flipped = world.flipped()
-            blocks.invalidate("culledCache")
+            blocks.invalidate("visibleCache")
           }
 
-          chunkData = blocks.culled(chunks, flipped === -1)
+          chunkData = blocks.visible(chunks, flipped === -1)
         },
         onRender: ({ world, delta, renderable }) => {
           const time = performance.now()

--- a/core/src/ecs/entities/blocks/BlockMesh.ts
+++ b/core/src/ecs/entities/blocks/BlockMesh.ts
@@ -50,6 +50,8 @@ export const BlockMesh = (type: "foreground" | "background") => {
           }
 
           chunkData = blocks.data(chunks, flipped === -1)
+
+          console.log("chunkData", chunkData.length)
         },
         onRender: ({ world, delta, renderable }) => {
           const time = performance.now()

--- a/web/src/components/Title.tsx
+++ b/web/src/components/Title.tsx
@@ -44,7 +44,7 @@ export const Title = ({ world, loginState, setLoginState }: TitleProps) => {
 
       <div style={{ position: 'absolute', right: 0, bottom: 0 }}>
         <span style={{ fontFamily: "sans-serif", fontSize: 14, marginRight: 5, verticalAlign: "-70%" }}>
-          v<b>0.19.5</b>
+          v<b>0.19.6</b>
         </span>
         <a style={{ margin: 0, color: "inherit", textDecoration: "none" }} target="_blank" href="https://discord.gg/VfFG9XqDpJ">
           <FaDiscord size={20} style={{ color: "white", verticalAlign: "-80%" }}></FaDiscord>


### PR DESCRIPTION
added `BlockData.visible` method to only get blocks that are visible 

before this change `BlockMesh` was rendering ~45k blocks, now it's rendering ~8k blocks