### PR TITLE
v0.27.6 mobile bugfixes

### DIFF
--- a/core/src/games/dde/Bird.ts
+++ b/core/src/games/dde/Bird.ts
@@ -27,7 +27,7 @@ const leap = 0.23
 export const Bird = (player: Player) => Character({
   id: `bird-${player.id}`,
   components: {
-    position: Position({ friction: true, gravity: 0.002, flying: false, z: 6, x: 20, y: 20 }),
+    position: Position({ friction: true, gravity: 0.002, flying: false, z: 6, x: 24, y: 18 }),
     networked: Networked(),
     collider: Collider({
       shape: "ball",

--- a/core/src/games/dde/DDE.ts
+++ b/core/src/games/dde/DDE.ts
@@ -88,7 +88,7 @@ const DDESystem = SystemBuilder({
           musicPlaying = false
         }
 
-        if (world.tick === 2) world.three?.resize()
+        if (world.tick === 40) world.three?.resize()
 
         const players = world.players()
         const characters = world.characters()

--- a/core/src/graphics/D3Renderer.ts
+++ b/core/src/graphics/D3Renderer.ts
@@ -62,7 +62,8 @@ export const D3Renderer = (c: HTMLCanvasElement): D3Renderer => {
       if (!webgl) return
 
       if (isMobile()) {
-        const height = document.fullscreenElement ? window.outerHeight : window.innerHeight
+        // @ts-expect-error
+        const height = (document.fullscreenElement || window.navigator.standalone) ? window.outerHeight : window.innerHeight
 
         webgl.setSize(window.innerWidth, height)
         renderer.camera.c.aspect = window.innerWidth / height

--- a/core/src/html/HtmlButton.ts
+++ b/core/src/html/HtmlButton.ts
@@ -13,6 +13,10 @@ export const HtmlButton = (props: HtmlButtonProps): HTMLButtonElement => {
   if (props.onHoverOut) b.addEventListener("pointerout", props.onHoverOut)
 
   b.oncontextmenu = (e) => e.preventDefault()
+  b.ontouchstart = (e) => e.preventDefault()
+  b.ontouchend = (e) => e.preventDefault()
+  b.ontouchmove = (e) => e.preventDefault()
+  b.ontouchcancel = (e) => e.preventDefault()
 
   Object.assign(b.style, props.style)
 

--- a/core/src/html/HtmlJoystick.ts
+++ b/core/src/html/HtmlJoystick.ts
@@ -22,6 +22,8 @@ export const HtmlJoystick = (client: Client, side: "left" | "right"): HTMLDivEle
   let center: XY = { x: 0, y: 0 }
 
   stick.onpointerdown = (e) => {
+    e.preventDefault()
+
     center = { x: stick.offsetLeft + e.offsetX, y: stick.offsetTop + e.offsetY }
 
     dragging = true

--- a/web/src/components/Title.tsx
+++ b/web/src/components/Title.tsx
@@ -43,7 +43,7 @@ export const Title = ({ world, loginState, setLoginState }: TitleProps) => {
 
       <div style={{ position: "absolute", right: 0, bottom: 0 }}>
         <span style={{ fontFamily: "sans-serif", fontSize: 14, marginRight: 5, verticalAlign: "-70%" }}>
-          v<b>0.27.5</b>
+          v<b>0.27.6</b>
         </span>
         <a style={{ margin: 0, color: "inherit", textDecoration: "none" }} target="_blank" href="https://discord.gg/VfFG9XqDpJ">
           <FaDiscord size={20} style={{ color: "white", verticalAlign: "-80%" }}></FaDiscord>


### PR DESCRIPTION
trying more fixes for mobile
- prevent double click magnifying glass / page zoom
- immediately resize to fullscreen on iOS standalone (`Add to Homescreen`)